### PR TITLE
Fix typo in infinite items text

### DIFF
--- a/data/maps/OldaleTown/scripts.inc
+++ b/data/maps/OldaleTown/scripts.inc
@@ -455,7 +455,7 @@ OldaleTown_Text_InfiniteItems3:
 	.string "You can not throw them away.$"
 
 OldaleTown_Text_InfiniteItems4:
-	.string "Cheat at your own responsability!$"
+	.string "Cheat at your own responsibility!$"
 
 OldaleTown_Text_InfiniteItemsNo:
 	.string "Okay!$"


### PR DESCRIPTION
## Description
Fixes a minor typo in the infite item text: `responsability` should be `responsibility`.