### PR TITLE
Resolve Build Errors with ARM GCC 10.3.1 20210621

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -3580,7 +3580,7 @@ static void BufferIvOrEvStats(u8 mode)
         PrintRightColumnStats();
         break;
     case 2:
-    default:
+    default: ;
         const s8 *natureMod = gNatureStatTable[
             (sMonSummaryScreen->summary.hiddenNature == HIDDEN_NATURE_NONE) ? sMonSummaryScreen->summary.nature : sMonSummaryScreen->summary.hiddenNature];
         BufferStat(currHPString, 0, hp, 0, 3);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When compiling `master` with arm-none-eabi-gcc version `10.3.1 20210621 (release)` via WSL2 Ubuntu an error is raised:

```
/usr/lib/gcc/arm-none-eabi/10.3.1/cc1 -quiet <flags> -o build/modern/src/pokemon_summary_screen.o src/pokemon_summary_screen.c
src/pokemon_summary_screen.c: In function 'BufferIvOrEvStats':
src/pokemon_summary_screen.c:3584:9: error: a label can only be part of a statement and a declaration is not a statement
 3584 |         const s8 *natureMod = gNatureStatTable[
      |         ^~~~~
make: *** [Makefile:340: build/modern/src/pokemon_summary_screen.o] Error 1
make: *** Deleting file 'build/modern/src/pokemon_summary_screen.o'
```

This is caused by the case statement `default:` immediately being followed by a declaration of a `const s8 *`, and is thus resolvable by simply placing a blank statement prior to evaluating the default switch case.

References:
https://stackoverflow.com/questions/18496282/why-do-i-get-a-label-can-only-be-part-of-a-statement-and-a-declaration-is-not-a
https://www.educative.io/answers/resolving-the-a-label-can-only-be-part-of-a-statement-error
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=37231

## **Discord contact info**
`hking0036`
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->