### PR TITLE
Correct edge cases for L=A setting

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -1655,6 +1655,11 @@ static void Task_HandleInput(u8 taskId)
                     SwitchToMoveSelection(taskId);
                 }
             }
+            // Carve out exception for L=A setting.
+            else if(gMain.newKeys & L_BUTTON)
+            {
+                BufferIvOrEvStats(1);
+            }
         }
         else if (JOY_NEW(B_BUTTON))
         {

--- a/src/tx_rac_menu.c
+++ b/src/tx_rac_menu.c
@@ -1550,7 +1550,8 @@ static void Task_OptionMenuFadeIn(u8 taskId)
 static void Task_OptionMenuProcessInput(u8 taskId)
 {
     int i, scrollCount = 0, itemsToRedraw;
-    if (JOY_NEW(A_BUTTON))
+    // Treat the L BUTTON as an L BUTTON even if the user has L=A set.
+    if (JOY_NEW(A_BUTTON) && !(JOY_NEW(L_BUTTON)))
     {
         if (sOptions->menuCursor[sOptions->submenu] == MenuItemCancel())
         {


### PR DESCRIPTION
Resolves #35 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Carves out a few of the edge cases where the L button in L=A should be treated as L:

- In the `tx_rac_menu`, the input is processed to determine the action, but if the user previously set `L=A` in the settings menu, the case for `A_BUTTON` is evaluated before the case for `L_BUTTON`, rendering it impossible to go backwards in the menus. By adding a check for the `A_BUTTON` case checking that the `L_BUTTON` was not being pressed simultaneously, we can correctly route the user's input for the menu.
    - This is not relevant for the regular settings in `options_plus_menu.c` because the `A_BUTTON` case is not evaluated.

- In the `pokemon_summary_screen`, on the `skills` menu, the A button has no effect in the Skills screen otherwise, and L=A users would otherwise be unable to see their Pokemon EVs.

## **Discord contact info**
`hking0036`