### PR TITLE
Add fix for randomizer in nuzlocke

### DIFF
--- a/src/tx_randomizer_and_challenges.c
+++ b/src/tx_randomizer_and_challenges.c
@@ -45,6 +45,8 @@ bool8 IsRandomizerActivated(void)
 
 bool8 IsRandomItemsActivated(void)
 {
+    if (!FlagGet(FLAG_ADVENTURE_STARTED))   //Don't randomize starting items
+        return FALSE;
     return gSaveBlock1Ptr->tx_Random_Items;
 }
 


### PR DESCRIPTION


## Description
Nuzlocke kicks in right after Pokeballs are given, but item randomizer can turn them into not-pokeballs. This means that people without a repel up are likely to lose their first encounter on Route 101, because they have no balls to use at all. Delaying the switch on only impacts guaranteed potion and Pokeballs, which is probably fine to let the players always have regardless of randomizer setting. 

## **Discord contact info**
insertcreativenamehere