### PR TITLE
Fix/challenges menu audio vblank

### DIFF
--- a/src/tx_rac_menu.c
+++ b/src/tx_rac_menu.c
@@ -17,6 +17,8 @@
 #include "strings.h"
 #include "string_util.h"
 #include "gba/m4a_internal.h"
+
+extern struct MusicPlayerInfo *gMPlay_PokemonCry;
 #include "constants/rgb.h"
 #include "battle_main.h"
 #include "tx_randomizer_and_challenges.h"
@@ -1422,6 +1424,8 @@ void CB2_InitTxRandomizerChallengesMenu(void)
     case 2:
         ResetPaletteFade();
         ScanlineEffect_Stop();
+        if (gMPlay_PokemonCry != NULL)
+            StopCryAndClearCrySongs();
         ResetTasks();
         ResetSpriteData();
         gMain.state++;

--- a/src/tx_rac_viewer.c
+++ b/src/tx_rac_viewer.c
@@ -18,6 +18,8 @@
 #include "international_string_util.h" // for GetStringRightAlignXOffset
 #include "strings.h"
 #include "gba/m4a_internal.h"
+
+extern struct MusicPlayerInfo *gMPlay_PokemonCry;
 #include "constants/rgb.h"
 #include "event_data.h"
 #include "tx_randomizer_and_challenges.h"
@@ -1220,6 +1222,8 @@ void CB2_InitChallengeViewer(void)
     case 2:
         ResetPaletteFade();
         ScanlineEffect_Stop();
+        if (gMPlay_PokemonCry != NULL)
+            StopCryAndClearCrySongs();
         ResetTasks();
         ResetSpriteData();
         gMain.state++;


### PR DESCRIPTION

**fix: stop audio state before ResetTasks in Challenges/RAC menu**

**Bug**
Opening the Challenges menu (PC → Challenges) caused screeching, layered noise over the overworld music after returning to the field. The noise persisted across map transitions and building entrances/exits until saving and resetting.

**Root Cause**
`CB2_InitTxRandomizerChallengesMenu` calls `ResetTasks()` as part of its init sequence. This destroys all active tasks mid-execution, including `Task_DuckBGMForPokemonCry` and `Task_Fanfare` if either happened to be running at the moment the menu was opened. Those tasks are responsible for restoring BGM volume to full (256) after a Pokémon cry ducks it to 85. Killing them early leaves `gMPlayInfo_BGM` permanently volume-ducked and its internal channel state dirty. When the field is restored, the audio engine resumes with that corrupted state, producing the screeching artifacts.

**Fix**
Stop all four `MusicPlayerInfo` channels and explicitly restore BGM volume before calling `ResetTasks()`, ensuring clean audio state when the menu takes over:

```c
m4aMPlayStop(&gMPlayInfo_BGM);
m4aMPlayStop(&gMPlayInfo_SE1);
m4aMPlayStop(&gMPlayInfo_SE2);
m4aMPlayStop(&gMPlayInfo_SE3);
m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 256);
ResetTasks();
```
