### PR TITLE
Animate front sprite on Pokedex info screen

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -563,6 +563,7 @@ void BattleAnimateFrontSprite(struct Sprite *sprite, u16 species, bool8 noCry, u
 void DoMonFrontSpriteAnimation(struct Sprite *sprite, u16 species, bool8 noCry, u8 panModeAnimFlag);
 void PokemonSummaryDoMonAnimation(struct Sprite *sprite, u16 species, bool8 oneFrame);
 void StopPokemonAnimationDelayTask(void);
+void StopFrontSpriteAnimationDelayTask(void);
 void BattleAnimateBackSprite(struct Sprite *sprite, u16 species);
 u8 GetOpposingLinkMultiBattlerId(bool8 rightSide, u8 multiplayerId);
 u16 FacilityClassToPicIndex(u16 facilityClass);

--- a/include/pokemon_animation.h
+++ b/include/pokemon_animation.h
@@ -3,6 +3,7 @@
 
 u8 GetSpeciesBackAnimSet(u16 species);
 void LaunchAnimationTaskForFrontSprite(struct Sprite *sprite, u8 frontAnimId);
+void StopMonFrontSpriteAnimationTask(void);
 void StartMonSummaryAnimation(struct Sprite *sprite, u8 frontAnimId);
 void LaunchAnimationTaskForBackSprite(struct Sprite *sprite, u8 backAnimSet);
 void SetSpriteCB_MonAnimDummy(struct Sprite *sprite);

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -26,6 +26,7 @@
 #include "pokedex_area_screen.h"
 #include "pokedex_cry_screen.h"
 #include "pokemon_icon.h"
+#include "pokemon_animation.h"
 #include "pokemon_summary_screen.h"
 #ifdef POKEMON_EXPANSION
 #include "region_map.h"
@@ -3821,6 +3822,56 @@ static u8 StartInfoScreenScroll(struct PokedexListItem *item, u8 taskId)
     return taskId;
 }
 
+// Task that waits for the front sprite animation to finish, then resets to frame 0
+#define tSpriteId data[0]
+static void Task_ResetSpriteAnimAfterDone(u8 taskId)
+{
+    u8 spriteId = gTasks[taskId].tSpriteId;
+    struct Sprite *sprite = &gSprites[spriteId];
+
+    if (!sprite->inUse)
+    {
+        DestroyTask(taskId);
+        return;
+    }
+    if (sprite->callback == SpriteCallbackDummy)
+    {
+        StartSpriteAnim(sprite, 0);
+        DestroyTask(taskId);
+    }
+}
+#undef tSpriteId
+
+// Stop any running sprite animation and destroy all associated tasks before freeing.
+static void StopMonSpriteAnimation(u8 spriteId)
+{
+    struct Sprite *sprite = &gSprites[spriteId];
+    u8 taskIdToDestroy;
+    u16 paletteIndex;
+    u16 i;
+
+    // Reset sprite position offset in case animation was mid-shake
+    sprite->x2 = 0;
+    sprite->y2 = 0;
+    sprite->callback = SpriteCallbackDummy;
+
+    // Restore sprite palette in case a glow/flash animation was mid-blend
+    paletteIndex = OBJ_PLTT_ID(sprite->oam.paletteNum);
+    for (i = 0; i < 16; i++)
+        gPlttBufferFaded[paletteIndex + i] = gPlttBufferUnfaded[paletteIndex + i];
+
+    // Directly destroy Task_HandleMonAnimation (the persistent animation driver)
+    StopMonFrontSpriteAnimationTask();
+
+    // Kill the delay task if the movement animation hasn't started yet
+    StopFrontSpriteAnimationDelayTask();
+
+    // Destroy the reset-after-done task
+    taskIdToDestroy = FindTaskIdByFunc(Task_ResetSpriteAnimAfterDone);
+    if (taskIdToDestroy != TASK_NONE)
+        DestroyTask(taskIdToDestroy);
+}
+
 static void Task_LoadInfoScreen(u8 taskId)
 {
     switch (gMain.state)
@@ -3921,6 +3972,22 @@ static void Task_LoadInfoScreen(u8 taskId)
             {
                 gMain.state++;
             }
+            // Play the front sprite animation (use DoMonFrontSpriteAnimation
+            // instead of PokemonSummaryDoMonAnimation to avoid flipping the sprite,
+            // since the Pokedex shows mons facing the same way as battle)
+            {
+                u16 species = NationalPokedexNumToSpecies(sPokedexListItem->dexNum);
+                u8 spriteId = gTasks[taskId].tMonSpriteId;
+                struct Sprite *monSprite = &gSprites[spriteId];
+                if (HasTwoFramesAnimation(species))
+                    StartSpriteAnim(monSprite, 1);
+                DoMonFrontSpriteAnimation(monSprite, species, TRUE, 0);
+                // Create a task to reset sprite back to frame 0 after animation ends
+                {
+                    u8 resetTaskId = CreateTask(Task_ResetSpriteAnimAfterDone, 10);
+                    gTasks[resetTaskId].data[0] = spriteId;
+                }
+            }
         }
         break;
     case 9:
@@ -3962,6 +4029,7 @@ static void Task_HandleInfoScreenInput(u8 taskId)
     if (gTasks[taskId].tScrolling)
     {
         // Scroll up/down
+        StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 16, RGB_BLACK);
         gTasks[taskId].func = Task_LoadInfoScreenWaitForFade;
         PlaySE(SE_DEX_SCROLL);
@@ -3969,6 +4037,7 @@ static void Task_HandleInfoScreenInput(u8 taskId)
     }
     if (JOY_NEW(B_BUTTON))
     {
+        StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 16, RGB_BLACK);
         // Use special exit handler if called from party menu
         if (sExternalReturnCallback != NULL)
@@ -3982,6 +4051,7 @@ static void Task_HandleInfoScreenInput(u8 taskId)
     if ((JOY_NEW(DPAD_RIGHT) || (JOY_NEW(R_BUTTON) && gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_LR)))
     {
         sPokedexView->selectedScreen = AREA_SCREEN;
+        StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
         BeginNormalPaletteFade(0xFFFFFFEB, 0, 0, 0x10, RGB_BLACK);
         sPokedexView->screenSwitchState = 1;
         gTasks[taskId].func = Task_SwitchScreensFromInfoScreen;
@@ -3994,6 +4064,7 @@ static void Task_SwitchScreensFromInfoScreen(u8 taskId)
 {
     if (!gPaletteFade.active)
     {
+        StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
         FreeAndDestroyMonPicSprite(gTasks[taskId].tMonSpriteId);
         switch (sPokedexView->screenSwitchState)
         {
@@ -4015,6 +4086,7 @@ static void Task_LoadInfoScreenWaitForFade(u8 taskId)
 {
     if (!gPaletteFade.active)
     {
+        StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
         FreeAndDestroyMonPicSprite(gTasks[taskId].tMonSpriteId);
         gTasks[taskId].func = Task_LoadInfoScreen;
     }
@@ -4024,6 +4096,7 @@ static void Task_ExitInfoScreen(u8 taskId)
 {
     if (!gPaletteFade.active)
     {
+        StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
         FreeAndDestroyMonPicSprite(gTasks[taskId].tMonSpriteId);
         FreeInfoScreenWindowAndBgBuffers();
         DestroyTask(taskId);
@@ -4034,6 +4107,7 @@ static void Task_ExitInfoScreenToExternal(u8 taskId)
 {
     if (!gPaletteFade.active)
     {
+        StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
         FreeAndDestroyMonPicSprite(gTasks[taskId].tMonSpriteId);
         FreeInfoScreenWindowAndBgBuffers();
         DestroyTask(taskId);

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -3979,6 +3979,10 @@ static void Task_LoadInfoScreen(u8 taskId)
                 u16 species = NationalPokedexNumToSpecies(sPokedexListItem->dexNum);
                 u8 spriteId = gTasks[taskId].tMonSpriteId;
                 struct Sprite *monSprite = &gSprites[spriteId];
+                // Swap anim table from the generic gAnims_MonPic to the per-species
+                // front anim table so that frame 0/1 switching uses species-specific
+                // timing (matches battle/summary behavior)
+                monSprite->anims = gMonFrontAnimsPtrTable[species];
                 if (HasTwoFramesAnimation(species))
                     StartSpriteAnim(monSprite, 1);
                 DoMonFrontSpriteAnimation(monSprite, species, TRUE, 0);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -11611,6 +11611,13 @@ void StopPokemonAnimationDelayTask(void)
         DestroyTask(delayTaskId);
 }
 
+void StopFrontSpriteAnimationDelayTask(void)
+{
+    u8 delayTaskId = FindTaskIdByFunc(Task_AnimateAfterDelay);
+    if (delayTaskId != TASK_NONE)
+        DestroyTask(delayTaskId);
+}
+
 void BattleAnimateBackSprite(struct Sprite *sprite, u16 species)
 {
     if (gSaveBlock2Ptr->optionsBattleSceneOff == 1)

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -996,6 +996,13 @@ void LaunchAnimationTaskForFrontSprite(struct Sprite *sprite, u8 frontAnimId)
     gTasks[taskId].tAnimId = frontAnimId;
 }
 
+void StopMonFrontSpriteAnimationTask(void)
+{
+    u8 taskId = FindTaskIdByFunc(Task_HandleMonAnimation);
+    if (taskId != TASK_NONE)
+        DestroyTask(taskId);
+}
+
 void StartMonSummaryAnimation(struct Sprite *sprite, u8 frontAnimId)
 {
     // sDontFlip is expected to still be FALSE here, not explicitly cleared


### PR DESCRIPTION
Play the Pokemon's front sprite animation when entering the info screen in the Pokedex. The animation triggers on every load: scrolling between entries (up/down), returning from sub-screens (Area/Cry/Size/Evo), and opening from the party Summary screen.

Uses DoMonFrontSpriteAnimation (battle-side path) instead of PokemonSummaryDoMonAnimation to avoid flipping the sprite, since the Pokedex displays mons facing the same direction as battle.

A helper task resets the sprite back to frame 0 after the animation completes, with a safety check for early navigation away.
