### PR TITLE
Fix Pokedex scroll stuck after Evolution screen jump

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -2363,6 +2363,7 @@ static void Task_WaitForExitInfoScreen(u8 taskId)
     else
     {
         // Exiting, back to list view
+        sPokedexView->sEvoScreenData.fromEvoPage = FALSE;
         sLastSelectedPokemon = sPokedexView->selectedPokemon;
         sPokeBallRotation = sPokedexView->pokeBallRotation;
         gTasks[taskId].func = Task_OpenPokedexMainPage;
@@ -8188,6 +8189,7 @@ static void Task_WaitForExitSearchResultsInfoScreen(u8 taskId)
     else
     {
         // Exiting, back to search results
+        sPokedexView->sEvoScreenData.fromEvoPage = FALSE;
         gTasks[taskId].func = Task_OpenSearchResults;
     }
 }


### PR DESCRIPTION
Minor bugfix.  When jumping to a different Pokemon via the Evolution screen's A button, the fromEvoPage flag is set to disable up/down scrolling (since the list position no longer matches the displayed entry). However, this flag was never cleared when exiting back to the Pokedex list, permanently disabling scroll for subsequent entries until the Pokedex was fully closed and reopened.

Clear fromEvoPage when returning to the list view from both the normal Pokedex and search results paths.
