### PR TITLE
Fix Battle Palace to use minted nature for move selection

### DIFF
--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -33,6 +33,7 @@ extern const struct CompressedSpriteSheet gSpriteSheet_EnemyShadow;
 extern const struct SpriteTemplate gSpriteTemplate_EnemyShadow;
 
 // this file's functions
+static u8 GetBattlePalaceNature(u8 battlerId);
 static u8 GetBattlePalaceMoveGroup(u16 move);
 static u16 GetBattlePalaceTarget(void);
 static void SpriteCB_TrainerSlideVertical(struct Sprite *sprite);
@@ -110,6 +111,20 @@ void FreeBattleSpritesData(void)
     FREE_AND_SET_NULL(gBattleSpritesDataPtr);
 }
 
+// Returns the effective nature for Battle Palace move selection.
+// Uses the minted nature if one has been applied, otherwise the original personality nature.
+static u8 GetBattlePalaceNature(u8 battlerId)
+{
+    struct Pokemon *mon;
+
+    if (GetBattlerSide(battlerId) == B_SIDE_PLAYER)
+        mon = &gPlayerParty[gBattlerPartyIndexes[battlerId]];
+    else
+        mon = &gEnemyParty[gBattlerPartyIndexes[battlerId]];
+
+    return GetNature(mon, TRUE);
+}
+
 // Pokémon chooses move to use in Battle Palace rather than player
 u16 ChooseMoveAndTargetInBattlePalace(void)
 {
@@ -143,7 +158,7 @@ u16 ChooseMoveAndTargetInBattlePalace(void)
     // Otherwise use move from "Support" group
     for (; i < maxGroupNum; i++)
     {
-        if (gBattlePalaceNatureToMoveGroupLikelihood[GetNatureFromPersonality(gBattleMons[gActiveBattler].personality)][i] > percent)
+        if (gBattlePalaceNatureToMoveGroupLikelihood[GetBattlePalaceNature(gActiveBattler)][i] > percent)
             break;
     }
     selectedGroup = i - minGroupNum;
@@ -342,7 +357,7 @@ static u16 GetBattlePalaceTarget(void)
         if (gBattleMons[opposing1].hp == gBattleMons[opposing2].hp)
             return (BATTLE_OPPOSITE(gActiveBattler & BIT_SIDE) + (Random() & 2)) << 8;
 
-        switch (gBattlePalaceNatureToMoveTarget[GetNatureFromPersonality(gBattleMons[gActiveBattler].personality)])
+        switch (gBattlePalaceNatureToMoveTarget[GetBattlePalaceNature(gActiveBattler)])
         {
         case PALACE_TARGET_STRONGER:
             if (gBattleMons[opposing1].hp > gBattleMons[opposing2].hp)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7188,9 +7188,18 @@ static void Cmd_various(void)
             && gBattleMons[gActiveBattler].hp != 0
             && !(gBattleMons[gActiveBattler].status1 & STATUS1_SLEEP))
         {
+            u8 palaceNature;
+            struct Pokemon *mon;
+
+            if (GetBattlerSide(gActiveBattler) == B_SIDE_PLAYER)
+                mon = &gPlayerParty[gBattlerPartyIndexes[gActiveBattler]];
+            else
+                mon = &gEnemyParty[gBattlerPartyIndexes[gActiveBattler]];
+            palaceNature = GetNature(mon, TRUE);
+
             gBattleStruct->palaceFlags |= gBitTable[gActiveBattler];
             gBattleCommunication[0] = TRUE;
-            gBattleCommunication[MULTISTRING_CHOOSER] = sBattlePalaceNatureToFlavorTextId[GetNatureFromPersonality(gBattleMons[gActiveBattler].personality)];
+            gBattleCommunication[MULTISTRING_CHOOSER] = sBattlePalaceNatureToFlavorTextId[palaceNature];
         }
         break;
     case VARIOUS_ARENA_JUDGMENT_WINDOW:


### PR DESCRIPTION
(feel free to reject this if you intended to point Palace AI at the born natures)
Ref: https://github.com/resetes12/pokeemerald/issues/116

**Summary**

Battle Palace (and Verdanturf Battle Tent) move selection, target preference, and flavor text were using `GetNatureFromPersonality()` which always reads the original nature from the personality value. This meant applying a mint had no effect on Palace behavior.

**Changes**

- Added `GetBattlePalaceNature()` helper in `battle_gfx_sfx_util.c` that fetches the party mon and calls `GetNature(mon, TRUE)`, returning the minted nature if one exists.
- Updated move group likelihood selection, target preference, and flavor text to use this helper.

**Notes**

- Classic/Vanilla users are unaffected since mints cannot be obtained in that mode.
- If no mint has been applied, `GetNature(mon, TRUE)` returns the personality nature (same as before).
- The Verdanturf Battle Tent uses `BATTLE_TYPE_PALACE` and goes through the same code path, so it's covered automatically.

## **Discord contact info**
aloven1191