### PR TITLE
fix: Pokedex map now shows correct locations for active encounter mode

### DIFF
--- a/src/pokedex_area_screen.c
+++ b/src/pokedex_area_screen.c
@@ -95,16 +95,6 @@ struct
     /*0xF70*/ u8 charBuffer[64];
     /*0xFB0*/ struct Sprite * areaUnknownSprites[3];
     /*0xFBC*/ u8 areaUnknownGraphicsBuffer[0x600];
-    // Cached encounter results for the *alternate* time mode so that toggling
-    // day↔night is a fast array swap rather than a full header re-scan.
-    // Populated once during DrawAreaGlow and kept live across toggles.
-    /*0x15BC*/ struct OverworldArea overworldAreasWithMons_alt[MAX_AREA_HIGHLIGHTS];
-    /*0x16BC*/ u16 numOverworldAreas_alt;
-    /*0x16BE*/ u16 specialAreaRegionMapSectionIds_alt[MAX_AREA_MARKERS];
-    /*0x16FE*/ u16 numSpecialAreas_alt;
-    // Pre-built glow tilemap for the alternate time mode, swapped on toggle
-    // so BuildAreaGlowTilemap is never called in the hot toggle path.
-    /*0x1700*/ u16 areaGlowTilemap_alt[AREA_SCREEN_WIDTH * AREA_SCREEN_HEIGHT];
 } static EWRAM_DATA *sPokedexAreaScreen = NULL;
 
 // ApplyTimeModeToAreaMapPalette reads the untinted palette directly from ROM via
@@ -127,7 +117,6 @@ static void ResetPokedexAreaMapBg(void);
 static void DestroyAreaScreenSprites(void);
 static void LoadHGSSScreenSelectBarSubmenu(void);
 static void CreateAreaIndicatorSprites(void);
-static void ContinueTimeModeRefresh(u8);
 static void ApplyTimeModeToAreaMapPalette(void);
 
 #include "rtc.h"
@@ -691,28 +680,6 @@ static bool8 DrawAreaGlow(void)
     switch (sPokedexAreaScreen->drawAreaGlowState)
     {
     case 0:
-        // Scan the alternate time mode first so its results land in the active
-        // arrays, which we then copy straight into the _alt cache.  Flipping
-        // back and re-scanning for the real current mode leaves the active
-        // arrays correct and both caches populated — all within a single frame.
-        sPokedexAreaScreen->areaViewTimeMode ^= 1;
-        FindMapsWithMon(sPokedexAreaScreen->species);
-        CpuCopy32(sPokedexAreaScreen->overworldAreasWithMons,
-                  sPokedexAreaScreen->overworldAreasWithMons_alt,
-                  sizeof(sPokedexAreaScreen->overworldAreasWithMons_alt));
-        sPokedexAreaScreen->numOverworldAreas_alt = sPokedexAreaScreen->numOverworldAreas;
-        CpuCopy16(sPokedexAreaScreen->specialAreaRegionMapSectionIds,
-                  sPokedexAreaScreen->specialAreaRegionMapSectionIds_alt,
-                  sizeof(sPokedexAreaScreen->specialAreaRegionMapSectionIds_alt));
-        sPokedexAreaScreen->numSpecialAreas_alt = sPokedexAreaScreen->numSpecialAreas;
-        // Also pre-build the alt glow tilemap while the alt encounter data is
-        // still in the active arrays, then copy it into the alt cache.
-        BuildAreaGlowTilemap();
-        CpuCopy16(sPokedexAreaScreen->areaGlowTilemap,
-                  sPokedexAreaScreen->areaGlowTilemap_alt,
-                  sizeof(sPokedexAreaScreen->areaGlowTilemap_alt));
-        // Restore the real mode and populate the active arrays.
-        sPokedexAreaScreen->areaViewTimeMode ^= 1;
         FindMapsWithMon(sPokedexAreaScreen->species);
         break;
     case 1:
@@ -814,6 +781,15 @@ static void FindMapsWithMon(u16 species)
         // Add regular species to the area map
         {
             u16 slotIndex = 0;
+            // Determine the active encounter slot: 0 = vanilla, 1 = modern.
+            u8 activeSlot;
+            if (gSaveBlock1Ptr->tx_Mode_Encounters == 1)
+                activeSlot = 1; // Modern always
+            else if (gSaveBlock1Ptr->tx_Mode_Encounters == 2 && FlagGet(FLAG_SYS_GAME_CLEAR))
+                activeSlot = 1; // Post-game after champion
+            else
+                activeSlot = 0; // Vanilla (mode 0, or mode 2 pre-champion)
+
             for (i = 0; gWildMonHeaders[i].mapGroup != MAP_GROUP(UNDEFINED); i++)
             {
                 // Track which time-slot offset we're at within a run of same-map headers.
@@ -826,17 +802,16 @@ static void FindMapsWithMon(u16 species)
                 else
                     slotIndex = 0;
 
-                // Only process the header for the currently viewed time mode.
-                // Single-slot maps (isMultiSlot == false) always pass through and
-                // are shown in both day and night views, which is correct — they
-                // have one encounter table that applies at all times.
-                
-                bool8 isMultiSlot = (slotIndex > 0)
-                    || (gWildMonHeaders[i+1].mapGroup != MAP_GROUP(UNDEFINED)
-                        && gWildMonHeaders[i].mapGroup == gWildMonHeaders[i+1].mapGroup
-                        && gWildMonHeaders[i].mapNum   == gWildMonHeaders[i+1].mapNum);
-                if (isMultiSlot && slotIndex != sPokedexAreaScreen->areaViewTimeMode)
-                    continue;
+                // Only process the header matching the player's active encounter table.
+                // Single-slot maps (isMultiSlot == false) always pass through.
+                {
+                    bool8 isMultiSlot = (slotIndex > 0)
+                        || (gWildMonHeaders[i+1].mapGroup != MAP_GROUP(UNDEFINED)
+                            && gWildMonHeaders[i].mapGroup == gWildMonHeaders[i+1].mapGroup
+                            && gWildMonHeaders[i].mapNum   == gWildMonHeaders[i+1].mapNum);
+                    if (isMultiSlot && slotIndex != activeSlot)
+                        continue;
+                }
 
                 if (MapHasSpecies(&gWildMonHeaders[i], species))
                 {
@@ -1251,12 +1226,6 @@ static void Task_HandlePokedexAreaScreenInput(u8 taskId)
         ApplyTimeModeToAreaMapPalette();
         break;
     case 1:
-        // If a multi-frame time-mode refresh is in progress, advance it and wait.
-        if (gTasks[taskId].data[2] != 0)
-        {
-            ContinueTimeModeRefresh(taskId);
-            return;
-        }
         //REMOVE "/*" & "*/" IF YOU WANT DAY/NIGHT BUTTON FUNCTINALITY. DISABLED BY DEFAULT SINCE MODERN EMERALD
         //DOESN'T CURRENTLY HAVE DAY/NIGHT ENCOUNTERS ANYMORE.
         
@@ -1500,111 +1469,4 @@ static void ApplyTimeModeToAreaMapPalette(void)
 }
 
 // Advances the multi-frame time-mode toggle refresh one step per frame.
-// Called from Task_HandlePokedexAreaScreenInput while data[2] != 0.
-// Three frames total:
-//   Frame 1 — swap all pre-built caches (encounters + glow tilemap) and DMA.
-//   Frame 2 — rebuild marker sprites and area-unknown sprites.
-//   Frame 3 — restart glow animation, flip indicator sprites, apply palette tint.
-static void ContinueTimeModeRefresh(u8 taskId)
-{
-    u16 i;
 
-    switch (gTasks[taskId].data[2])
-    {
-    case 1:
-        // Frame 1: swap the active and alt encounter caches (pre-computed at
-        // initial load — no header re-scan needed), swap the pre-built glow
-        // tilemaps, and DMA the correct one into VRAM.  Zero BLDALPHA first so
-        // the old highlight disappears cleanly.
-        SetGpuReg(REG_OFFSET_BLDALPHA, BLDALPHA_BLEND(0, 16));
-        {
-            u16 j, tmp16;
-            struct OverworldArea tmpArea;
-
-            // Swap overworld (route/town) encounter arrays.
-            for (j = 0; j < MAX_AREA_HIGHLIGHTS; j++)
-            {
-                tmpArea = sPokedexAreaScreen->overworldAreasWithMons[j];
-                sPokedexAreaScreen->overworldAreasWithMons[j] = sPokedexAreaScreen->overworldAreasWithMons_alt[j];
-                sPokedexAreaScreen->overworldAreasWithMons_alt[j] = tmpArea;
-            }
-            tmp16 = sPokedexAreaScreen->numOverworldAreas;
-            sPokedexAreaScreen->numOverworldAreas     = sPokedexAreaScreen->numOverworldAreas_alt;
-            sPokedexAreaScreen->numOverworldAreas_alt = tmp16;
-
-            // Swap special-area (dungeon/landmark) marker arrays.
-            for (j = 0; j < MAX_AREA_MARKERS; j++)
-            {
-                tmp16 = sPokedexAreaScreen->specialAreaRegionMapSectionIds[j];
-                sPokedexAreaScreen->specialAreaRegionMapSectionIds[j] = sPokedexAreaScreen->specialAreaRegionMapSectionIds_alt[j];
-                sPokedexAreaScreen->specialAreaRegionMapSectionIds_alt[j] = tmp16;
-            }
-            tmp16 = sPokedexAreaScreen->numSpecialAreas;
-            sPokedexAreaScreen->numSpecialAreas     = sPokedexAreaScreen->numSpecialAreas_alt;
-            sPokedexAreaScreen->numSpecialAreas_alt = tmp16;
-
-            // Swap pre-built glow tilemaps so no rebuild is needed.
-            for (j = 0; j < AREA_SCREEN_WIDTH * AREA_SCREEN_HEIGHT; j++)
-            {
-                tmp16 = sPokedexAreaScreen->areaGlowTilemap[j];
-                sPokedexAreaScreen->areaGlowTilemap[j] = sPokedexAreaScreen->areaGlowTilemap_alt[j];
-                sPokedexAreaScreen->areaGlowTilemap_alt[j] = tmp16;
-            }
-        }
-        // DMA the swapped tilemap into VRAM.  LoadBgTilemap schedules a direct
-        // DMA — do NOT call CopyBgTilemapBufferToVram afterwards.
-        LoadBgTilemap(2, sPokedexAreaScreen->areaGlowTilemap, sizeof(sPokedexAreaScreen->areaGlowTilemap), 0);
-        gTasks[taskId].data[2] = 2;
-        break;
-    case 2:
-        // Frame 2: destroy and recreate marker sprites and Area Unknown sprites.
-        FreeSpriteTilesByTag(TAG_AREA_MARKER);
-        FreeSpritePaletteByTag(TAG_AREA_MARKER);
-        for (i = 0; i < sPokedexAreaScreen->numAreaMarkerSprites; i++)
-            DestroySprite(sPokedexAreaScreen->areaMarkerSprites[i]);
-        sPokedexAreaScreen->numAreaMarkerSprites = 0;
-        CreateAreaMarkerSprites();
-
-        // Area Unknown sprites: the decompressed graphics in areaUnknownGraphicsBuffer
-        // never change between modes, so skip LZ77UnCompWram and just re-upload
-        // the existing buffer to OBJ VRAM via LoadSpriteSheet.
-        // NOTE: do NOT free TAG_AREA_UNKNOWN's palette — indicator sprites share it.
-        FreeSpriteTilesByTag(TAG_AREA_UNKNOWN);
-        for (i = 0; i < ARRAY_COUNT(sPokedexAreaScreen->areaUnknownSprites); i++)
-        {
-            if (sPokedexAreaScreen->areaUnknownSprites[i])
-                DestroySprite(sPokedexAreaScreen->areaUnknownSprites[i]);
-            sPokedexAreaScreen->areaUnknownSprites[i] = NULL;
-        }
-        {
-            struct SpriteSheet spriteSheet = {
-                .data = sPokedexAreaScreen->areaUnknownGraphicsBuffer,
-                .size = sizeof(sPokedexAreaScreen->areaUnknownGraphicsBuffer),
-                .tag  = TAG_AREA_UNKNOWN,
-            };
-            LoadSpriteSheet(&spriteSheet);
-            // Palette is shared with the indicator sprites and is already loaded;
-            // LoadSpritePalette is a no-op if the tag is already registered, but
-            // call it anyway to be safe in case it was evicted.
-            LoadSpritePalette(&sAreaUnknownSpritePalette);
-        }
-        CreateAreaUnknownSprites();
-        gTasks[taskId].data[2] = 3;
-        break;
-    case 3:
-        // Frame 3: restart glow animation, flip indicator sprites, apply palette tint.
-        StartAreaGlow();
-        if (sPokedexAreaScreen->indDaySpriteId != MAX_SPRITES)
-        {
-            bool8 dayInvis   = (sPokedexAreaScreen->areaViewTimeMode != 0);
-            bool8 nightInvis = (sPokedexAreaScreen->areaViewTimeMode == 0);
-            gSprites[sPokedexAreaScreen->indDaySpriteId].invisible       = dayInvis;
-            gSprites[sPokedexAreaScreen->indDaySpriteId + 1].invisible   = dayInvis;
-            gSprites[sPokedexAreaScreen->indNightSpriteId].invisible     = nightInvis;
-            gSprites[sPokedexAreaScreen->indNightSpriteId + 1].invisible = nightInvis;
-        }
-        ApplyTimeModeToAreaMapPalette();
-        gTasks[taskId].data[2] = 0; // refresh complete
-        break;
-    }
-}


### PR DESCRIPTION
## Bug

The Pokedex "Area" screen always showed "Area Unknown" for species that only exist in the modern encounter tables (Charmeleon, Ivysaur, Wartortle, Happiny, etc.) — even when the player was using Modern Encounters mode and had caught the Pokémon in-game.

## Root Cause

The area screen's encounter-table scanning loop used a leftover day/night time-mode variable (`areaViewTimeMode`) to decide which slot to read when a map had multiple consecutive encounter headers. Since the vanilla and modern tables are stored as consecutive entries for the same map (slotIndex 0 and 1), and the day/night toggle was disabled, the code always defaulted to scanning slotIndex 0 (vanilla) — never finding modern-only species.

## Fix

Replace the time-based slot selection with a direct check of `tx_Mode_Encounters` and `FLAG_SYS_GAME_CLEAR`:
- **Vanilla (mode 0):** scans slot 0
- **Modern (mode 1):** scans slot 1
- **Post-game (mode 2):** scans slot 0 pre-champion, slot 1 post-champion

Also removes the unused alternate-cache system (`ContinueTimeModeRefresh` and `_alt` struct fields) that supported the disabled day/night toggle (~3KB heap savings).

## Testing

Verified Charmeleon, Wartortle, and Ivysaur correctly show Safari Zone locations on the area map when using Modern Encounters mode.
