### PR TITLE
Hide run prompt during Birch intro battle

### DIFF
--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -2720,6 +2720,8 @@ void BufferStringBattle(u16 stringID)
                 stringPtr = sText_WildPkmnAppearedPause;
             else if (gBattleTypeFlags & BATTLE_TYPE_SAFARI)
                 stringPtr = sText_WildPkmnAppearedOld;
+            else if (gBattleTypeFlags & BATTLE_TYPE_FIRST_BATTLE)
+                stringPtr = sText_WildPkmnAppearedOld;
             else
                 if (gSaveBlock2Ptr->optionsLRtoRun == 0)
                 {


### PR DESCRIPTION
`BATTLE_TYPE_FIRST_BATTLE` prevents running but wasn't excluded from the quick run prompt text selection, so the player would see 'Run? L+R+A' or 'Run? Hold B.' even though escape is impossible.  It's probably the most important prompt to skip since a first time player might be confused.   I simply added this battle type to the existing logic that handles
BATTLE_TYPE_LEGENDARY
BATTLE_TYPE_DOUBLE
BATTLE_TYPE_WALLY_TUTORIAL
BATTLE_TYPE_SAFARI
already.