### PR TITLE
Fix sell menu price clipping with FRLG font

### DIFF
--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -1261,10 +1261,11 @@ static void PrintItemQuantity(u8 windowId, s16 quantity)
 static void PrintItemSoldAmount(int windowId, int numSold, int moneyEarned)
 {
     u8 numDigits = (gBagPosition.pocket == BERRIES_POCKET) ? BERRY_CAPACITY_DIGITS : BAG_ITEM_CAPACITY_DIGITS;
+    u8 moneyX = (gSaveBlock2Ptr->optionsFontType) ? 30 : 32;
     ConvertIntToDecimalStringN(gStringVar1, numSold, STR_CONV_MODE_LEADING_ZEROS, numDigits);
     StringExpandPlaceholders(gStringVar4, gText_xVar1);
     AddTextPrinterParameterized(windowId, FONT_NORMAL, gStringVar4, 0, 1, TEXT_SKIP_DRAW, 0);
-    PrintMoneyAmount(windowId, 32, 1, moneyEarned, 0);
+    PrintMoneyAmount(windowId, moneyX, 1, moneyEarned, 0);
 }
 
 static void Task_BagMenu_HandleInput(u8 taskId)


### PR DESCRIPTION
The buy menu adjusts the money x-offset from 32 to 30 when FRLG font is active (wider glyphs), but the sell menu's PrintItemSoldAmount always used 32, causing the price to clip against the right window edge. Apply the same font-conditional offset.

Emerald font example - Sell Menu (no bug)
<img width="240" height="160" alt="pokeemerald_modern-7" src="https://github.com/user-attachments/assets/df3a5cc2-7e42-4382-b004-b9a6ec977f50" />

FRLG font example  - Sell Menu (bug, needs the same offset as Buy menu)
<img width="240" height="160" alt="pokeemerald_modern-6" src="https://github.com/user-attachments/assets/d3a7f9ab-83da-4eee-ab3e-79e1d3a170a4" />

FRLG font example - Buy Menu (no bug, offset was already correct)
<img width="240" height="160" alt="pokeemerald_modern-5" src="https://github.com/user-attachments/assets/2b36b716-1c40-49c0-b333-fee177cc8adb" />
