### PR TITLE
Fix Growth Mulch not advancing berry tree stage

### DIFF
--- a/src/data/items.h
+++ b/src/data/items.h
@@ -698,7 +698,7 @@ const struct Item gItems[] =
         .price = 2500,
         .description = sFertilizerDesc,
         .pocket = POCKET_ITEMS,
-        .type = ITEM_USE_BAG_MENU,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_Fertilizer,
     },
 
@@ -5554,7 +5554,7 @@ const struct Item gItems2[] =
         .price = 2500,
         .description = sFertilizerDesc,
         .pocket = POCKET_ITEMS,
-        .type = ITEM_USE_BAG_MENU,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_Fertilizer,
     },
 

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1282,16 +1282,21 @@ void ItemUseOutOfBattle_Fertilizer(u8 taskId)
 {  
     if (TryToWaterBerryTree() == TRUE)
     {
-        RemoveUsedItem();
-        FadeInFromBlack();
-        CB2_ReturnToField();
-        LockPlayerFieldControls();
-        ScriptContext_SetupScript(BerryTree_EventScript_BerryTree);
+        sItemUseOnFieldCB = ItemUseOnFieldCB_Fertilizer;
+        SetUpItemUseOnFieldCallback(taskId);
     }
     else
     {
         DisplayDadsAdviceCannotUseItemMessage(taskId, gTasks[taskId].tUsingRegisteredKeyItem);
     }
+}
+
+static void ItemUseOnFieldCB_Fertilizer(u8 taskId)
+{
+    RemoveUsedItem();
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(BerryTree_EventScript_BerryTree);
+    DestroyTask(taskId);
 }
 
 void ItemUseOutOfBattle_CannotUse(u8 taskId)


### PR DESCRIPTION
**Description:**

In _some_ circumstances, Growth Mulch was consumed but the berry tree never advanced — it stayed permanently stuck at its current growth stage. The root cause was `ItemUseOutOfBattle_Fertilizer` bypassing the standard field callback system:

- It called `CB2_ReturnToField()` and `ScriptContext_SetupScript()` directly from within the bag menu context
- The berry script (`Berry_Ready`) executed before the field was fully reinitialized, so `gSelectedObjectEvent` was stale and the wrong tree (or no tree) was modified
- The item's type was `ITEM_USE_BAG_MENU`, which is incompatible with the field callback infrastructure

**Fix:** Use the same `SetUpItemUseOnFieldCallback` pattern used by WailmerPail and Escape Rope. Changed item type to `ITEM_USE_FIELD` so the bag closes properly before the callback fires.

**Testing:**
- Planted berries at Berry Master's garden (12 plots, all occupied)
- Used Growth Mulch — tree advances to harvestable stage with sparkle animation
- Confirmed mulch is consumed and tree can be picked
- No crash, no stuck state on reset/re-entry

Fixes https://github.com/resetes12/pokeemerald/issues/128

If you want to replicate this bug, I can provide a SAV where it's happening in the current `master` build.
[pokeemerald_modern_berryissue.sav.zip](https://github.com/user-attachments/files/29609257/pokeemerald_modern_berryissue.sav.zip)
