### PR TITLE
Add designated follower system

### DIFF
--- a/include/event_object_movement.h
+++ b/include/event_object_movement.h
@@ -125,6 +125,8 @@ void ClearObjectEventMovement(struct ObjectEvent *objectEvent, struct Sprite *sp
 void ObjectEventClearHeldMovement(struct ObjectEvent *);
 void ObjectEventClearHeldMovementIfActive(struct ObjectEvent *);
 struct Pokemon * GetFirstLiveMon(void);
+struct Pokemon * GetDesignatedFollowerMon(void);
+bool8 IsFollowerSpeciesLarge(u16 species);
 void UpdateFollowingPokemon(void);
 void RemoveFollowingPokemon(void);
 struct ObjectEvent * GetFollowerObject(void);

--- a/include/global.h
+++ b/include/global.h
@@ -1108,7 +1108,8 @@ struct SaveBlock1
     /*0x3B58*/ LilycoveLady lilycoveLady;
     /*0x3B98*/ struct TrainerNameRecord trainerNameRecords[20];
     /*0x3C88*/ u8 registeredTexts[UNION_ROOM_KB_ROW_COUNT][21];
-    /*0x3D5A*/ u8 unused_3D5A[10];
+    /*0x3D5A*/ u8 designatedFollower; // 0 = none (fallback to first live), 1-6 = party slot + 1
+    /*0x3D5B*/ u8 unused_3D5B[9];
     /*0x3D64*/ struct TrainerHillSave trainerHill;
     /*0x3D70*/ struct WaldaPhrase waldaPhrase;
     /*0x3D88*/ u8 NuzlockeEncounterFlags[9]; //tx_randomizer_and_challenges

--- a/include/strings.h
+++ b/include/strings.h
@@ -3216,5 +3216,7 @@ extern const u8 gText_BattleRules_NoItems_Player[];
 extern const u8 gText_UnitSystemMetric[];   //tx_optionsPlus
 extern const u8 gText_UnitSystemImperial[]; //tx_optionsPlus
 extern const u8 gText_Var1DotVar2_Metric[];
+extern const u8 gText_Follow[];
+extern const u8 gText_PkmnWillFollowYou[];
 
 #endif // GUARD_STRINGS_H

--- a/src/data/party_menu.h
+++ b/src/data/party_menu.h
@@ -117,6 +117,7 @@ static const u8 sFontColorTable[][3] =
     {TEXT_COLOR_TRANSPARENT, TEXT_DYNAMIC_COLOR_2,  TEXT_DYNAMIC_COLOR_3},  // Gender symbol
     {TEXT_COLOR_WHITE,       TEXT_COLOR_DARK_GRAY,  TEXT_COLOR_LIGHT_GRAY}, // Selection actions
     {TEXT_COLOR_WHITE,       TEXT_COLOR_BLUE,       TEXT_COLOR_LIGHT_BLUE}, // Field moves
+    {TEXT_COLOR_WHITE,       TEXT_COLOR_GREEN,      TEXT_COLOR_LIGHT_GREEN}, // Follow
     {TEXT_COLOR_TRANSPARENT, TEXT_COLOR_WHITE,      TEXT_COLOR_DARK_GRAY},  // Unused
 };
 
@@ -677,6 +678,7 @@ struct
     [MENU_TRADE1] = {gText_Trade4, CursorCb_Trade1},
     [MENU_TRADE2] = {gText_Trade4, CursorCb_Trade2},
     [MENU_TOSS] = {gMenuText_Toss, CursorCb_Toss},
+    [MENU_FOLLOW] = {gText_Follow, CursorCb_Follow},
     [MENU_FIELD_MOVES + FIELD_MOVE_CUT] = {gMoveNames[MOVE_CUT], CursorCb_FieldMove},
     [MENU_FIELD_MOVES + FIELD_MOVE_FLASH] = {gMoveNames[MOVE_FLASH], CursorCb_FieldMove},
     [MENU_FIELD_MOVES + FIELD_MOVE_ROCK_SMASH] = {gMoveNames[MOVE_ROCK_SMASH], CursorCb_FieldMove},

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2049,6 +2049,30 @@ struct ObjectEvent *GetFollowerObject(void) { // Return follower ObjectEvent or 
     return NULL;
 }
 
+// Return TRUE if a species has a 64px tall follower sprite (considered "large")
+bool8 IsFollowerSpeciesLarge(u16 species) {
+    const struct ObjectEventGraphicsInfo *info = SpeciesToGraphicsInfo(species, 0);
+    return info->height == 64;
+}
+
+// Return the pokemon that is currently following the player.
+// Uses the designated follower if valid, otherwise falls back to first live mon.
+struct Pokemon *GetDesignatedFollowerMon(void) {
+    if (gSaveBlock2Ptr->optionsfollowerEnable == 0)
+    {
+        u8 df = gSaveBlock1Ptr->designatedFollower;
+        if (df != 0 && df <= PARTY_SIZE
+            && !InBattlePyramid()
+            && GetMonData(&gPlayerParty[df - 1], MON_DATA_SPECIES) != SPECIES_NONE
+            && GetMonData(&gPlayerParty[df - 1], MON_DATA_HP) > 0
+            && !GetMonData(&gPlayerParty[df - 1], MON_DATA_IS_EGG))
+        {
+            return &gPlayerParty[df - 1];
+        }
+    }
+    return GetFirstLiveMon();
+}
+
 // Return graphicsInfo for a pokemon species & form
 static const struct ObjectEventGraphicsInfo *SpeciesToGraphicsInfo(u16 species, u8 form) {
     const struct ObjectEventGraphicsInfo *graphicsInfo;
@@ -2231,7 +2255,19 @@ static bool8 GetMonInfo(struct Pokemon * mon, u16 *species, u8 *form, u8 *shiny)
 static bool8 GetFollowerInfo(u16 *species, u8 *form, u8 *shiny) 
 {
     if (gSaveBlock2Ptr->optionsfollowerEnable == 0) 
+    {
+        u8 df = gSaveBlock1Ptr->designatedFollower; // 0 = none, 1-6 = slot+1
+        if (df != 0 && df <= PARTY_SIZE
+            && !InBattlePyramid()
+            && GetMonData(&gPlayerParty[df - 1], MON_DATA_SPECIES) != SPECIES_NONE
+            && GetMonData(&gPlayerParty[df - 1], MON_DATA_HP) > 0
+            && !GetMonData(&gPlayerParty[df - 1], MON_DATA_IS_EGG))
+        {
+            return GetMonInfo(&gPlayerParty[df - 1], species, form, shiny);
+        }
+        // Fallback to first live mon
         return GetMonInfo(GetFirstLiveMon(), species, form, shiny);
+    }
     else
         return FALSE;
 }
@@ -2251,6 +2287,19 @@ void UpdateFollowingPokemon(void) { // Update following pokemon if any
         FlagGet(FLAG_TEMP_HIDE_FOLLOWER) ||
         (gSaveBlock2Ptr->optionsfollowerLargeEnable == 1) && SpeciesToGraphicsInfo(species, 0)->height == 64)
     {
+        // Auto-clear designated follower if it's a large mon and big followers is off
+        if (gSaveBlock2Ptr->optionsfollowerLargeEnable == 1
+            && gSaveBlock1Ptr->designatedFollower != 0)
+        {
+            u8 df = gSaveBlock1Ptr->designatedFollower;
+            if (df <= PARTY_SIZE
+                && GetMonData(&gPlayerParty[df - 1], MON_DATA_SPECIES) != SPECIES_NONE)
+            {
+                u16 dfSpecies = GetMonData(&gPlayerParty[df - 1], MON_DATA_SPECIES);
+                if (SpeciesToGraphicsInfo(dfSpecies, 0)->height == 64)
+                    gSaveBlock1Ptr->designatedFollower = 0;
+            }
+        }
         RemoveFollowingPokemon();
         return;
     }
@@ -2438,7 +2487,7 @@ bool8 ScrFunc_getfolloweraction(struct ScriptContext *ctx) // Essentially a big 
     u32 condCount = 0;
     u32 emotion;
     struct ObjectEvent *objEvent = GetFollowerObject();
-    struct Pokemon *mon = GetFirstLiveMon();
+    struct Pokemon *mon = GetDesignatedFollowerMon();
     u8 emotion_weight[FOLLOWER_EMOTION_LENGTH] = {
         [FOLLOWER_EMOTION_HAPPY] = 10,
         [FOLLOWER_EMOTION_NEUTRAL] = 15,
@@ -6125,7 +6174,7 @@ bool8 ScrFunc_GetDirectionToFace(struct ScriptContext *ctx) {
 bool8 ScrFunc_IsFollowerFieldMoveUser(struct ScriptContext *ctx) {
     u16 *var = GetVarPointer(ScriptReadHalfword(ctx));
     u16 userIndex = gFieldEffectArguments[0]; // field move user index
-    struct Pokemon *follower = GetFirstLiveMon();
+    struct Pokemon *follower = GetDesignatedFollowerMon();
     struct ObjectEvent *obj = GetFollowerObject();
     if (var == NULL)
         return FALSE;
@@ -7482,7 +7531,7 @@ static void ObjectEventSetPokeballGfx(struct ObjectEvent *objEvent) {
     #if OW_MON_POKEBALLS
     u32 ball = BALL_POKE;
     if (objEvent->localId == OBJ_EVENT_ID_FOLLOWER) {
-        struct Pokemon *mon = GetFirstLiveMon();
+        struct Pokemon *mon = GetDesignatedFollowerMon();
         if (mon)
             ball = ItemIdToBallId(GetMonData(mon, MON_DATA_POKEBALL));
     }

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -97,6 +97,7 @@ enum {
     MENU_TRADE1,
     MENU_TRADE2,
     MENU_TOSS,
+    MENU_FOLLOW,
     MENU_FIELD_MOVES
 };
 
@@ -198,7 +199,7 @@ struct PartyMenuInternal
     u32 spriteIdCancelPokeball:7;
     u32 messageId:14;
     u8 windowId[3];
-    u8 actions[9];
+    u8 actions[10];
     u8 numActions;
     // In vanilla Emerald, only the first 0xB0 hwords (0x160 bytes) are actually used.
     // However, a full 0x100 hwords (0x200 bytes) are allocated.
@@ -481,6 +482,7 @@ static void CursorCb_Register(u8);
 static void CursorCb_Trade1(u8);
 static void CursorCb_Trade2(u8);
 static void CursorCb_Toss(u8);
+static void CursorCb_Follow(u8);
 static void CursorCb_FieldMove(u8);
 static bool8 SetUpFieldMove_Surf(void);
 static bool8 SetUpFieldMove_Fly(void);
@@ -2602,7 +2604,8 @@ static u8 DisplaySelectionWindow(u8 windowType)
 
     for (i = 0; i < sPartyMenuInternal->numActions; i++)
     {
-        u8 fontColorsId = (sPartyMenuInternal->actions[i] >= MENU_FIELD_MOVES) ? 4 : 3;
+        u8 fontColorsId = (sPartyMenuInternal->actions[i] >= MENU_FIELD_MOVES) ? 4
+                         : (sPartyMenuInternal->actions[i] == MENU_FOLLOW) ? 5 : 3;
         AddTextPrinterParameterized4(sPartyMenuInternal->windowId[0], FONT_NORMAL, cursorDimension, (i * 16) + 1, letterSpacing, 0, sFontColorTable[fontColorsId], 0, sCursorOptions[sPartyMenuInternal->actions[i]].text);
     }
 
@@ -2732,6 +2735,26 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
     }
     if (!InBattlePike())
     {
+        // Add "Follow" option if followers are enabled, mon is alive, not an egg,
+        // not already the active follower, and not a large mon when big followers is off
+        if (gSaveBlock2Ptr->optionsfollowerEnable == 0
+            && !InBattlePyramid()
+            && sPartyMenuInternal->numActions < 6
+            && GetMonData(&mons[slotId], MON_DATA_HP) > 0
+            && !GetMonData(&mons[slotId], MON_DATA_IS_EGG)
+            && gSaveBlock1Ptr->designatedFollower != slotId + 1
+            && !(gSaveBlock2Ptr->optionsfollowerLargeEnable == 1
+                 && IsFollowerSpeciesLarge(GetMonData(&mons[slotId], MON_DATA_SPECIES))))
+        {
+            // Don't show if this is already the effective follower (first live mon with no designation)
+            u8 df = gSaveBlock1Ptr->designatedFollower;
+            bool8 designatedValid = df != 0 && df <= PARTY_SIZE
+                && GetMonData(&mons[df - 1], MON_DATA_SPECIES) != SPECIES_NONE
+                && GetMonData(&mons[df - 1], MON_DATA_HP) > 0
+                && !GetMonData(&mons[df - 1], MON_DATA_IS_EGG);
+            if (designatedValid || &mons[slotId] != GetFirstLiveMon())
+                AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, MENU_FOLLOW);
+        }
         if (GetMonData(&mons[1], MON_DATA_SPECIES) != SPECIES_NONE)
             AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, MENU_SWITCH);
         if (ItemIsMail(GetMonData(&mons[slotId], MON_DATA_HELD_ITEM)))
@@ -3138,6 +3161,12 @@ static void SwitchPartyMon(void)
     SwitchMenuBoxSprites(&menuBoxes[0]->itemSpriteId, &menuBoxes[1]->itemSpriteId);
     SwitchMenuBoxSprites(&menuBoxes[0]->monSpriteId, &menuBoxes[1]->monSpriteId);
     SwitchMenuBoxSprites(&menuBoxes[0]->statusSpriteId, &menuBoxes[1]->statusSpriteId);
+
+    // Track designated follower through party swaps (0=none, 1-6=slot+1)
+    if (gSaveBlock1Ptr->designatedFollower == gPartyMenu.slotId + 1)
+        gSaveBlock1Ptr->designatedFollower = gPartyMenu.slotId2 + 1;
+    else if (gSaveBlock1Ptr->designatedFollower == gPartyMenu.slotId2 + 1)
+        gSaveBlock1Ptr->designatedFollower = gPartyMenu.slotId + 1;
 }
 
 // Finish switching mons or using Softboiled
@@ -3803,6 +3832,24 @@ static void Task_HandleSpinTradeYesNoInput(u8 taskId)
         Task_ReturnToChooseMonAfterText(taskId);
         break;
     }
+}
+
+static void CursorCb_Follow(u8 taskId)
+{
+    struct Pokemon *mon = &gPlayerParty[gPartyMenu.slotId];
+
+    PlaySE(SE_SELECT);
+    PartyMenuRemoveWindow(&sPartyMenuInternal->windowId[0]);
+    PartyMenuRemoveWindow(&sPartyMenuInternal->windowId[1]);
+
+    // Set designated follower to the selected party slot (stored as slot+1, 0=none)
+    gSaveBlock1Ptr->designatedFollower = gPartyMenu.slotId + 1;
+
+    // Show confirmation message
+    GetMonNickname(mon, gStringVar1);
+    StringExpandPlaceholders(gStringVar4, gText_PkmnWillFollowYou);
+    DisplayPartyMenuMessage(gStringVar4, TRUE);
+    gTasks[taskId].func = Task_ReturnToChooseMonAfterText;
 }
 
 static void CursorCb_FieldMove(u8 taskId)

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -6440,7 +6440,11 @@ static void RefreshDisplayMon(void)
 static void SetMovingMonData(u8 boxId, u8 position)
 {
     if (boxId == TOTAL_BOXES_COUNT)
+    {
+        if (gSaveBlock1Ptr->designatedFollower == position + 1)
+            gSaveBlock1Ptr->designatedFollower = 0;
         sStorage->movingMon = gPlayerParty[sCursorPosition];
+    }
     else
         BoxMonAtToMon(boxId, position, &sStorage->movingMon);
 
@@ -6977,6 +6981,10 @@ s16 CompactPartySlots(void)
 {
     s16 retVal = -1;
     u16 i, last;
+    u8 slotMap[PARTY_SIZE];
+
+    for (i = 0; i < PARTY_SIZE; i++)
+        slotMap[i] = PARTY_SIZE; // Mark as removed
 
     for (i = 0, last = 0; i < PARTY_SIZE; i++)
     {
@@ -6985,6 +6993,7 @@ s16 CompactPartySlots(void)
         {
             if (i != last)
                 gPlayerParty[last] = gPlayerParty[i];
+            slotMap[i] = last;
             last++;
         }
         else if (retVal == -1)
@@ -6994,6 +7003,18 @@ s16 CompactPartySlots(void)
     }
     for (; last < PARTY_SIZE; last++)
         ZeroMonData(&gPlayerParty[last]);
+
+    // Update designated follower slot to track compaction (0=none, 1-6=slot+1)
+    {
+        u8 df = gSaveBlock1Ptr->designatedFollower;
+        if (df != 0 && df <= PARTY_SIZE)
+        {
+            if (slotMap[df - 1] >= PARTY_SIZE)
+                gSaveBlock1Ptr->designatedFollower = 0; // Mon was removed
+            else
+                gSaveBlock1Ptr->designatedFollower = slotMap[df - 1] + 1;
+        }
+    }
 
     return retVal;
 }

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1750,8 +1750,9 @@ bool8 ScrCmd_bufferleadmonspeciesname(struct ScriptContext *ctx)
 bool8 ScrFunc_bufferlivemonnickname(struct ScriptContext *ctx)
 {
     u8 stringVarIndex = ScriptReadByte(ctx);
+    struct Pokemon *mon = GetDesignatedFollowerMon();
 
-    GetMonData(GetFirstLiveMon(), MON_DATA_NICKNAME, sScriptStringVars[stringVarIndex]);
+    GetMonData(mon, MON_DATA_NICKNAME, sScriptStringVars[stringVarIndex]);
     StringGet_Nickname(sScriptStringVars[stringVarIndex]);
     return FALSE;
 }
@@ -2246,7 +2247,7 @@ bool8 ScrCmd_playmoncry(struct ScriptContext *ctx)
 
 bool8   ScrFunc_playfirstmoncry(struct ScriptContext *ctx)
 {
-    u16 species = GetMonData(GetFirstLiveMon(), MON_DATA_SPECIES);
+    u16 species = GetMonData(GetDesignatedFollowerMon(), MON_DATA_SPECIES);
     PlayCry_Script(species, 0);
     return FALSE;
 }

--- a/src/strings.c
+++ b/src/strings.c
@@ -2022,3 +2022,5 @@ const u8 gText_FORMS_Buttons_Submenu_Decapped_PE[]  = _("{START_BUTTON}Evos");
 const u8 gText_FORMS_NONE[]                         = _("{STR_VAR_1} has no alternate forms.");
 const u8 gText_Var1DotVar2_Metric[]                 = _("{STR_VAR_1}.{STR_VAR_2}cm");
 const u8 gText_StatEditor[] = _("Edit IVs/EVs");
+const u8 gText_Follow[] = _("Follow");
+const u8 gText_PkmnWillFollowYou[] = _("{STR_VAR_1} will now follow\nyou!{PAUSE_UNTIL_PRESS}");

--- a/src/trade.c
+++ b/src/trade.c
@@ -3116,6 +3116,14 @@ static void TradeMons(u8 playerPartyIdx, u8 partnerPartyIdx)
     struct Pokemon *partnerMon = &gEnemyParty[partnerPartyIdx];
     u16 partnerMail = GetMonData(partnerMon, MON_DATA_MAIL);
 
+    // Clear designated follower if the traded mon was the follower,
+    // unless this is the self-trader (gSpecialVar_0x8004 == 6, same mon returned)
+    if (gSaveBlock1Ptr->designatedFollower == playerPartyIdx + 1
+        && gSpecialVar_0x8004 != 6)
+    {
+        gSaveBlock1Ptr->designatedFollower = 0;
+    }
+
     // The mail attached to the sent Pokémon no longer exists in your file.
     if (playerMail != MAIL_NONE)
         ClearMail(&gSaveBlock1Ptr->mail[playerMail]);


### PR DESCRIPTION
**Description:**

Allows the player to choose which party Pokémon follows them via a "Follow" option in the party menu, instead of always defaulting to the first live mon.

**Changes:**
- 1-byte SaveBlock1 field from unused padding (save-compatible with existing saves)
- Green "Follow" option in party menu, context-aware (hidden when followers off, mon fainted/egg, already following, large mon with big followers off, in Battle Pyramid)
- Tracks designation through party swaps, clears on deposit/release/trade (except self-trader)
- CompactPartySlots remaps the slot index correctly
- Auto-clears if big followers toggled off for a large designated mon
- Battle Pyramid falls back to first live mon (party is rearranged there)
- Follower interactions (cry, nickname, emotion, pokeball sprite) use the designated mon
- When cleared (flag = 0), reverts to existing behavior (first unfainted party mon)

Built from partial functionality in https://github.com/resetes12/pokeemerald/pull/98
<img width="240" height="160" alt="pokeemerald_modern-25" src="https://github.com/user-attachments/assets/3ba726c1-f19b-4bce-9b70-a9c6a37c4a41" />
<img width="240" height="160" alt="pokeemerald_modern-26" src="https://github.com/user-attachments/assets/89f51f8d-d71b-4d32-8df1-7b48a4c2d758" />
