### PR TITLE
Fix hard mode item limit counting bag opens instead of item uses

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4931,7 +4931,6 @@ static void HandleTurnActionSelectionState(void)
                     {
                         BtlController_EmitChooseItem(BUFFER_A, gBattleStruct->battlerPartyOrders[gActiveBattler]);
                         MarkBattlerForControllerExec(gActiveBattler);
-                        gItemLimit++;
                        }
                     break;
                 case B_ACTION_SWITCH:
@@ -5126,6 +5125,7 @@ static void HandleTurnActionSelectionState(void)
                     else
                     {
                         gLastUsedItem = (gBattleBufferB[gActiveBattler][1] | (gBattleBufferB[gActiveBattler][2] << 8));
+                        gItemLimit++;
                         gBattleCommunication[gActiveBattler]++;
                     }
                     break;


### PR DESCRIPTION
The 4-item limit on hard mode was incrementing gItemLimit when the player opened the bag, not when they confirmed an item. This meant opening and canceling the bag, or browsing without using anything, still counted toward the limit. In doubles this was especially punishing since each battler's bag open counted separately.

Resolves https://github.com/resetes12/pokeemerald/issues/133
