### PR TITLE
QoL: Remember target selection per battler in doubles

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -714,6 +714,7 @@ extern u8 *gLinkBattleRecvBuffer;
 extern struct BattleResources *gBattleResources;
 extern u8 gActionSelectionCursor[MAX_BATTLERS_COUNT];
 extern u8 gMoveSelectionCursor[MAX_BATTLERS_COUNT];
+extern u8 gTargetSelectionCursor[MAX_BATTLERS_COUNT];
 extern u8 gBattlerStatusSummaryTaskId[MAX_BATTLERS_COUNT];
 extern u8 gBattlerInMenuId;
 extern bool8 gDoingBattleAnim;

--- a/include/battle.h
+++ b/include/battle.h
@@ -715,6 +715,7 @@ extern struct BattleResources *gBattleResources;
 extern u8 gActionSelectionCursor[MAX_BATTLERS_COUNT];
 extern u8 gMoveSelectionCursor[MAX_BATTLERS_COUNT];
 extern u8 gTargetSelectionCursor[MAX_BATTLERS_COUNT];
+extern u8 gTargetSelectionMove[MAX_BATTLERS_COUNT];
 extern u8 gBattlerStatusSummaryTaskId[MAX_BATTLERS_COUNT];
 extern u8 gBattlerInMenuId;
 extern bool8 gDoingBattleAnim;

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -544,6 +544,7 @@ static void HandleInputChooseTarget(void)
         PlaySE(SE_SELECT);
         gSprites[gBattlerSpriteIds[gMultiUsePlayerCursor]].callback = SpriteCB_HideAsMoveTarget;
         gTargetSelectionCursor[gActiveBattler] = gMultiUsePlayerCursor;
+        gTargetSelectionMove[gActiveBattler] = gMoveSelectionCursor[gActiveBattler];
         BtlController_EmitTwoReturnValues(BUFFER_B, 10, gMoveSelectionCursor[gActiveBattler] | (gMultiUsePlayerCursor << 8));
         EndBounceEffect(gMultiUsePlayerCursor, BOUNCE_HEALTHBOX);
         TryHideLastUsedBall();
@@ -715,6 +716,7 @@ static void HandleInputChooseMove(void)
             if (moveTarget & (MOVE_TARGET_USER | MOVE_TARGET_USER_OR_SELECTED))
                 gMultiUsePlayerCursor = gActiveBattler;
             else if (gTargetSelectionCursor[gActiveBattler] != 0xFF
+                     && gTargetSelectionMove[gActiveBattler] == gMoveSelectionCursor[gActiveBattler]
                      && !(gAbsentBattlerFlags & gBitTable[gTargetSelectionCursor[gActiveBattler]])
                      && gBattleMons[gTargetSelectionCursor[gActiveBattler]].hp > 0)
                 gMultiUsePlayerCursor = gTargetSelectionCursor[gActiveBattler];

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -543,6 +543,7 @@ static void HandleInputChooseTarget(void)
     {
         PlaySE(SE_SELECT);
         gSprites[gBattlerSpriteIds[gMultiUsePlayerCursor]].callback = SpriteCB_HideAsMoveTarget;
+        gTargetSelectionCursor[gActiveBattler] = gMultiUsePlayerCursor;
         BtlController_EmitTwoReturnValues(BUFFER_B, 10, gMoveSelectionCursor[gActiveBattler] | (gMultiUsePlayerCursor << 8));
         EndBounceEffect(gMultiUsePlayerCursor, BOUNCE_HEALTHBOX);
         TryHideLastUsedBall();
@@ -713,6 +714,10 @@ static void HandleInputChooseMove(void)
 
             if (moveTarget & (MOVE_TARGET_USER | MOVE_TARGET_USER_OR_SELECTED))
                 gMultiUsePlayerCursor = gActiveBattler;
+            else if (gTargetSelectionCursor[gActiveBattler] != 0xFF
+                     && !(gAbsentBattlerFlags & gBitTable[gTargetSelectionCursor[gActiveBattler]])
+                     && gBattleMons[gTargetSelectionCursor[gActiveBattler]].hp > 0)
+                gMultiUsePlayerCursor = gTargetSelectionCursor[gActiveBattler];
             else if (gAbsentBattlerFlags & gBitTable[GetBattlerAtPosition(B_POSITION_OPPONENT_LEFT)])
                 gMultiUsePlayerCursor = GetBattlerAtPosition(B_POSITION_OPPONENT_RIGHT);
             else

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -232,6 +232,7 @@ EWRAM_DATA struct BattleResources *gBattleResources = NULL;
 EWRAM_DATA u8 gActionSelectionCursor[MAX_BATTLERS_COUNT] = {0};
 EWRAM_DATA u8 gMoveSelectionCursor[MAX_BATTLERS_COUNT] = {0};
 EWRAM_DATA u8 gTargetSelectionCursor[MAX_BATTLERS_COUNT] = {0};
+EWRAM_DATA u8 gTargetSelectionMove[MAX_BATTLERS_COUNT] = {0};
 EWRAM_DATA u8 gBattlerStatusSummaryTaskId[MAX_BATTLERS_COUNT] = {0};
 EWRAM_DATA u8 gBattlerInMenuId = 0;
 EWRAM_DATA bool8 gDoingBattleAnim = FALSE;
@@ -3642,6 +3643,9 @@ static void BattleStartClearSetData(void)
         gBattleResources->flags->flags[i] = 0;
         gPalaceSelectionBattleScripts[i] = 0;
         gTargetSelectionCursor[i] = 0xFF;
+        gTargetSelectionMove[i] = 0xFF;
+        gActionSelectionCursor[i] = 0;
+        gMoveSelectionCursor[i] = 0;
     }
 
     for (i = 0; i < 2; i++)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -231,6 +231,7 @@ EWRAM_DATA u8 *gLinkBattleRecvBuffer = NULL;
 EWRAM_DATA struct BattleResources *gBattleResources = NULL;
 EWRAM_DATA u8 gActionSelectionCursor[MAX_BATTLERS_COUNT] = {0};
 EWRAM_DATA u8 gMoveSelectionCursor[MAX_BATTLERS_COUNT] = {0};
+EWRAM_DATA u8 gTargetSelectionCursor[MAX_BATTLERS_COUNT] = {0};
 EWRAM_DATA u8 gBattlerStatusSummaryTaskId[MAX_BATTLERS_COUNT] = {0};
 EWRAM_DATA u8 gBattlerInMenuId = 0;
 EWRAM_DATA bool8 gDoingBattleAnim = FALSE;
@@ -3640,6 +3641,7 @@ static void BattleStartClearSetData(void)
         gLastPrintedMoves[i] = MOVE_NONE;
         gBattleResources->flags->flags[i] = 0;
         gPalaceSelectionBattleScripts[i] = 0;
+        gTargetSelectionCursor[i] = 0xFF;
     }
 
     for (i = 0; i < 2; i++)
@@ -3787,6 +3789,7 @@ void SwitchInClearSetData(void)
 
     gActionSelectionCursor[gActiveBattler] = 0;
     gMoveSelectionCursor[gActiveBattler] = 0;
+    gTargetSelectionCursor[gActiveBattler] = 0xFF;
 
     ptr = (u8 *)&gDisableStructs[gActiveBattler];
     for (i = 0; i < sizeof(struct DisableStruct); i++)
@@ -3869,6 +3872,7 @@ void FaintClearSetData(void)
 
     gActionSelectionCursor[gActiveBattler] = 0;
     gMoveSelectionCursor[gActiveBattler] = 0;
+    gTargetSelectionCursor[gActiveBattler] = 0xFF;
 
     ptr = (u8 *)&gDisableStructs[gActiveBattler];
     for (i = 0; i < sizeof(struct DisableStruct); i++)


### PR DESCRIPTION
In doubles, the target cursor always defaulted to opponent left regardless of previous selection. Now each battler remembers its last confirmed target and defaults to it on the next turn, with safeguards:

- Only restores the remembered target if the same move slot is selected (prevents Light Screen → Flamethrower carrying an ally target to an attack)
- Falls back to default (opponent left/right) if remembered target fainted or is absent
- All cursors (action, move, target) reset at battle start so new battles always begin on Fight  (apparently that wasn't the case, but very rare to catch since usually previous battles were won on a Fight command)
- Target cursor resets on switch/faint as expected