### PR TITLE
Fix stats toggle intercepting SELECT on regular summary screen

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -2388,14 +2388,6 @@ static void Task_HandleInput_MoveSelect(u8 taskId)
             PlaySE(SE_SELECT);
             CloseMoveSelectMode(taskId);
         }
-        else if (JOY_NEW(SELECT_BUTTON))
-        {
-            if (sMonSummaryScreen->currPageIndex == PSS_PAGE_BATTLE_MOVES)
-            {
-                PlaySE(SE_SELECT);
-                ToggleStatsOverlay();
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Woops - didnt think the change would also impact the Summary screen too.  Fixed.  (i dont think Select did anything on Summary in the moves menu before, anyway.)

The stats overlay SELECT handler was incorrectly added to Task_HandleInput_MoveSelect (regular summary move-swap mode), blocking the existing move rearrange functionality. Remove it so the toggle only works in Task_HandleReplaceMoveInput (the move-learning/forget flow) as intended.