### PR TITLE
Fix field move menu showing known Fly/Flash and preserving move order

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2712,23 +2712,31 @@ static void SetPartyMonFieldSelectionActions(struct Pokemon *mons, u8 slotId)
     }
     else
     {
+        bool8 knowsFly = FALSE;
+        bool8 knowsFlash = FALSE;
+
+        // Add all known field moves in moveset order (including Fly/Flash)
         for (i = 0; i < MAX_MON_MOVES; i++)
         {
             for (j = 0; sFieldMoves[j] != FIELD_MOVES_COUNT; j++)
             {
                 if (GetMonData(&mons[slotId], i + MON_DATA_MOVE1) == sFieldMoves[j])
                 {
-                    if (sFieldMoves[j] != MOVE_FLY) // If Mon already knows FLY, prevent it from being added to action list
-                        if (sFieldMoves[j] != MOVE_FLASH) // If Mon already knows FLASH, prevent it from being added to action list
-                            AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, j + MENU_FIELD_MOVES);
-                            break;
+                    if (sFieldMoves[j] == MOVE_FLY)
+                        knowsFly = TRUE;
+                    if (sFieldMoves[j] == MOVE_FLASH)
+                        knowsFlash = TRUE;
+                    AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, j + MENU_FIELD_MOVES);
+                    break;
                 }
             }
         }
-        if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM02 - ITEM_TM01)) // If Mon can learn HM02 and action list consists of < 4 moves, add FLY to action list
-            AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 5 + MENU_FIELD_MOVES);
-        if (sPartyMenuInternal->numActions < 5 && CanMonLearnTMHM(&mons[slotId], ITEM_HM05 - ITEM_TM01)) // If Mon can learn HM05 and action list consists of < 4 moves, add FLASH to action list
+        // If there's room and mon can learn Fly/Flash but doesn't know them, add as extras
+        // Flash is prioritized over Fly since Flash has no alternative access (Fly can be triggered from the map)
+        if (sPartyMenuInternal->numActions < 6 && !knowsFlash && CanMonLearnTMHM(&mons[slotId], ITEM_HM05 - ITEM_TM01))
             AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 1 + MENU_FIELD_MOVES);
+        if (sPartyMenuInternal->numActions < 6 && !knowsFly && CanMonLearnTMHM(&mons[slotId], ITEM_HM02 - ITEM_TM01))
+            AppendToList(sPartyMenuInternal->actions, &sPartyMenuInternal->numActions, 5 + MENU_FIELD_MOVES);
     }
     if (!InBattlePike())
     {


### PR DESCRIPTION
**Description:**

The non-HMsOverwrite party menu path was filtering Fly and Flash from the known-moves loop, then trying to re-add them as HM-bag extras with a cap that often failed. This caused two issues:

1. A mon that actually *knows* Fly or Flash wouldn't see them in the menu if other field moves already hit the cap
2. Field moves appeared in an inconsistent order — known moves showed in moveset order but Fly/Flash were always appended at the end regardless of where they sat in the moveset

**What changed:**
- All known field moves (including Fly/Flash) are now added in moveset slot order (slot 1 → slot 4)
- Fly/Flash are only appended as HM-bag extras if the mon can learn them but doesn't already know them, and only if there's room
- Raised the extras cap from `< 5` to `< 6` to accommodate Debug mode's Edit IVs/EVs taking a slot
- Flash is prioritized over Fly in the optional logic.  Fly can be used from the Hoenn map, Flash has no other way to use in context (i think?)

**Impact scenarios:**

| Case | Before | After |
|------|--------|-------|
| Mew knows Strength/Surf/Rock Smash/Flash (non-lead) | Strength, Surf, Rock Smash shown. Flash stripped and not re-added (cap hit) | All 4 shown in moveset order |
| Mon knows Fly in slot 1, Cut in slot 2 | Cut shown, Fly appended at end (if room) | Fly shown first, then Cut (moveset order) |
| Mon doesn't know Fly but can learn it, 2 field moves known | 2 known + Fly extra | Same behavior (Fly extra added) |
| Debug on, mon knows 2 field moves | 2 known + Fly extra, Flash blocked by cap | 2 known + Fly + Flash (both extras fit) |
| Mon knows 4 field moves (none are Fly/Flash) | All 4 shown | Same (no change, extras only added if not known) |

**No impact on:**
- The HMsOverwrite path (slot 0 handling) — unchanged
- Battle Pike behavior — unchanged  
- Any non-field-move menu entries — unchanged