### PR TITLE
Fix shade weather palette being overwritten by time-of-day blend

### DIFF
--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1683,18 +1683,11 @@ static void OverworldBasic(void)
             || cachedBlend.time1 != currentTimeBlend.time1
             || cachedBlend.weight != currentTimeBlend.weight)
         {
-            // Temp fix for Weather Shade. Blending palette when updating time is stopped in the overworld,
-            // so the shade remains, instead of fading with the new blended time.
-
-            // Blending resumes after opening a menu or battling, so it kinda works.
-
-            // It mostly affects FakeRTC, as normal RTC overworld palette change don't happen as often,
-            // and only affects three maps (Petalburg Woods, Souther Island interior and Faraway Island interior).
-            if (GetSavedWeather() != WEATHER_SHADE)
-            {
-                UpdateAltBgPalettes(PALETTES_BG);
-                UpdatePalettesWithTime(PALETTES_ALL);
-            }
+            UpdateAltBgPalettes(PALETTES_BG);
+            UpdatePalettesWithTime(PALETTES_ALL);
+            // Re-apply weather color map after time blend so shade/darkening isn't lost
+            if (gWeatherPtr->colorMapIndex != 0)
+                ApplyWeatherColorMapIfIdle(gWeatherPtr->colorMapIndex);
         }
     }
 }


### PR DESCRIPTION
**Description:**

Replaces the temporal fix (commit acbccc0) that skipped all time-of-day palette updates in shade weather maps.

**Problem:** When the day/night system updated palettes in `OverworldBasic`, it overwrote the shade darkening with a fresh time blend, making shaded maps (Petalburg Woods, Southern/Faraway Island) lose their shade effect until a menu or battle forced a full palette reload. The workaround disabled time updates entirely in those maps, breaking day/night transitions there.

**Fix:** Apply the time blend normally, then re-apply the weather color map on top. Both effects now coexist — shade stays consistent while time-of-day smoothly transitions.

**Affected maps:** Petalburg Woods, Southern Island Interior, Faraway Island Interior, Abandoned Ship rooms, Navel Rock depths, Cave of Origin (any map using `WEATHER_SHADE`).

**Tested with:** FakeRTC in Petalburg Woods — shade persists through rapid time transitions, palette smoothly shifts without flickering or loss of shade.