### PR TITLE
Fix type effectiveness randomizer: persistence, bounds, and symmetry

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -1108,7 +1108,9 @@ struct SaveBlock1
     /*0x3B58*/ LilycoveLady lilycoveLady;
     /*0x3B98*/ struct TrainerNameRecord trainerNameRecords[20];
     /*0x3C88*/ u8 registeredTexts[UNION_ROOM_KB_ROW_COUNT][21];
-    /*0x3D5A*/ u8 unused_3D5A[10];
+    /*0x3D5A*/ u8 unused_3D5A_reserved; // reserved for designatedFollower in separate PR
+    /*0x3D5B*/ u16 typeRandomizerSeed;
+    /*0x3D5D*/ u8 unused_3D5D[7];
     /*0x3D64*/ struct TrainerHillSave trainerHill;
     /*0x3D70*/ struct WaldaPhrase waldaPhrase;
     /*0x3D88*/ u8 NuzlockeEncounterFlags[9]; //tx_randomizer_and_challenges

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1466,9 +1466,9 @@ s32 GetTypeEffectiveness(struct Pokemon *mon, u8 moveType) {
             }
             else if (GetTypeEffectivenessRandom(TYPE_EFFECT_ATK_TYPE(i)) == moveType) {
                 // check type1
-                if (TYPE_EFFECT_DEF_TYPE(i) == type1)
+                if (GetTypeEffectivenessRandom(TYPE_EFFECT_DEF_TYPE(i)) == type1)
                     multiplier = TYPE_EFFECT_MULTIPLIER(i);
-                else if (TYPE_EFFECT_DEF_TYPE(i) == type2 && type1 != type2)
+                else if (GetTypeEffectivenessRandom(TYPE_EFFECT_DEF_TYPE(i)) == type2 && type1 != type2)
                     multiplier = TYPE_EFFECT_MULTIPLIER(i);
                 else {
                     i += 3;
@@ -1513,9 +1513,9 @@ s32 GetTypeEffectiveness(struct Pokemon *mon, u8 moveType) {
             }
             else if (GetTypeEffectivenessRandom(TYPE_EFFECT_ATK_TYPE_OLD(i)) == moveType) {
                 // check type1
-                if (TYPE_EFFECT_DEF_TYPE_OLD(i) == type1)
+                if (GetTypeEffectivenessRandom(TYPE_EFFECT_DEF_TYPE_OLD(i)) == type1)
                     multiplier = TYPE_EFFECT_MULTIPLIER_OLD(i);
-                else if (TYPE_EFFECT_DEF_TYPE_OLD(i) == type2 && type1 != type2)
+                else if (GetTypeEffectivenessRandom(TYPE_EFFECT_DEF_TYPE_OLD(i)) == type2 && type1 != type2)
                     multiplier = TYPE_EFFECT_MULTIPLIER_OLD(i);
                 else {
                     i += 3;

--- a/src/intro.c
+++ b/src/intro.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "main.h"
 #include "palette.h"
+#include "pokemon.h"
 #include "scanline_effect.h"
 #include "task.h"
 #include "title_screen.h"
@@ -1156,6 +1157,7 @@ void CB2_InitCopyrightScreenAfterBootup(void)
         LoadGameSave(SAVE_NORMAL);
         if (gSaveFileStatus == SAVE_STATUS_EMPTY || gSaveFileStatus == SAVE_STATUS_CORRUPT)
             Sav2_ClearSetDefault();
+        RandomizeTypeEffectivenessListEWRAM(gSaveBlock1Ptr->typeRandomizerSeed);
         SetPokemonCryStereo(gSaveBlock2Ptr->optionsSound);
         InitHeap(gHeap, HEAP_SIZE);
     }

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -241,7 +241,8 @@ void NewGameInitData(void)
     WipeTrainerNameRecords();
     ResetTrainerHillResults();
     ResetContestLinkResults();
-    RandomizeTypeEffectivenessListEWRAM(Random32());
+    gSaveBlock1Ptr->typeRandomizerSeed = Random32() & 0xFFFF;
+    RandomizeTypeEffectivenessListEWRAM(gSaveBlock1Ptr->typeRandomizerSeed);
     if ((gSaveBlock1Ptr->tx_Nuzlocke_EasyMode) && (gSaveBlock1Ptr->tx_Challenges_Nuzlocke))
         gSaveBlock1Ptr->tx_Nuzlocke_EasyMode = 0;
 

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -11931,18 +11931,17 @@ u8 *MonSpritesGfxManager_GetSpritePtr(u8 managerId, u8 spriteNum)
 //******************* tx_randomizer_and_challenges
 void RandomizeTypeEffectivenessListEWRAM(u16 seed)
 {
-    u8 i;
+    u8 i, j;
     u8 stemp[RANDOM_TYPE_COUNT];
 
     memcpy(stemp, sOneTypeChallengeValidTypes, sizeof(sOneTypeChallengeValidTypes));
     ShuffleListU8(stemp, NELEMS(sOneTypeChallengeValidTypes), seed);
 
-    sTypeEffectivenessList[TYPE_MYSTERY] = TYPE_NORMAL;
-    for (i=0; i<NUMBER_OF_MON_TYPES; i++)
+    sTypeEffectivenessList[TYPE_MYSTERY] = TYPE_MYSTERY;
+    for (i = 0, j = 0; i < NUMBER_OF_MON_TYPES; i++)
     {
         if (i != TYPE_MYSTERY)
-            sTypeEffectivenessList[i] = stemp[i];
-
+            sTypeEffectivenessList[i] = stemp[j++];
     }
 }
 u8 GetTypeEffectivenessRandom(u8 type)


### PR DESCRIPTION
**Description:**

Three bugs fixed in the type effectiveness randomizer:

**1. Table lost on save/load (critical)**
The shuffled type mapping lived in EWRAM (zeroed on power cycle) with a non-deterministic seed that was never saved. After reloading, `GetTypeEffectivenessRandom()` returned 0 (TYPE_NORMAL) for every type, making all moves treated as Normal-type for effectiveness. Fixed by storing the seed in SaveBlock1 (`typeRandomizerSeed`, 2 bytes from unused padding) and regenerating the table on game load.

**2. Array out-of-bounds (undefined behavior)**
`RandomizeTypeEffectivenessListEWRAM` iterated `NUMBER_OF_MON_TYPES` (19) times indexing into an 18-element shuffled array, skipping `TYPE_MYSTERY` (index 9) but not adjusting the source index. Indices 10-18 read `stemp[10]`-`stemp[18]` — one past the end. Fixed with a separate counter `j` for the source array.

**3. Asymmetric offensive/defensive randomization (design bug)**
Only the attacking type column was remapped via `GetTypeEffectivenessRandom()`. The defending type was compared raw against the target's types. This meant if Fire was remapped to Water offensively, Fire-type defenders still used Fire's original defensive resistances/weaknesses. Now both `TYPE_EFFECT_ATK_TYPE` and `TYPE_EFFECT_DEF_TYPE` are remapped, making the shuffled chart fully symmetric and consistent.

**Save compatibility:** Old saves with `typeRandomizerSeed == 0` will generate a valid (though different) shuffle on load. The randomizer was already broken on reload for those saves anyway.