### PR TITLE
Critical - Fix SaveBlock1 alignment: typeRandomizerSeed at odd offset corrupted save

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -1111,8 +1111,9 @@ struct SaveBlock1
     /*0x3B98*/ struct TrainerNameRecord trainerNameRecords[20];
     /*0x3C88*/ u8 registeredTexts[UNION_ROOM_KB_ROW_COUNT][21];
     /*0x3D5A*/ u8 designatedFollower; // 0 = none (fallback to first live), 1-6 = party slot + 1
-    /*0x3D5B*/ u16 typeRandomizerSeed;
-    /*0x3D5D*/ u8 unused_3D5D[7];
+    /*0x3D5B*/ u8 unused_3D5B;
+    /*0x3D5C*/ u16 typeRandomizerSeed;
+    /*0x3D5E*/ u8 unused_3D5E[6];
     /*0x3D64*/ struct TrainerHillSave trainerHill;
     /*0x3D70*/ struct WaldaPhrase waldaPhrase;
     /*0x3D88*/ u8 NuzlockeEncounterFlags[9]; //tx_randomizer_and_challenges


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>The <code>typeRandomizerSeed</code> (u16) was placed at offset <code>0x3D5B</code> — an odd address. Since <code>struct SaveBlock1</code> has no <code>__attribute__((packed))</code>, the compiler inserted an implicit padding byte to align the u16 to <code>0x3D5C</code>. This silently shifted all fields after it by 1 byte, corrupting the challenge bitfield block (<code>tx_Challenges_PartyLimit</code>, etc.) when loading existing saves. Fix: explicit padding byte so the layout matches the comments.</p>
<p>No permanent damage if the player didn't save while running the broken build.</p>
<hr>
<h2>SaveBlock1 Layout (0x3D5A region)</h2>

Offset | Size | Field | Source
-- | -- | -- | --
0x3D5A | 1 byte | designatedFollower | feature/designated-follower PR
0x3D5B | 1 byte | unused_3D5B (explicit padding) | alignment fix
0x3D5C | 2 bytes | typeRandomizerSeed | fix/type-effectiveness-randomizer PR
0x3D5E | 6 bytes | unused_3D5E[6] | free
0x3D64 | — | trainerHill (existing) | —


<hr>
<p><strong>Free space remaining:</strong> 6 bytes at <code>0x3D5E</code>–<code>0x3D63</code> in SaveBlock1. Any future additions to this region should use even offsets for u16/u32 fields, or use u8 fields at odd offsets to avoid repeating this bug.</p>
</body></html>