### PR TITLE
feat: add 2x Battle Speed option

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -719,6 +719,11 @@ extern u8 gTargetSelectionMove[MAX_BATTLERS_COUNT];
 extern u8 gBattlerStatusSummaryTaskId[MAX_BATTLERS_COUNT];
 extern u8 gBattlerInMenuId;
 extern bool8 gDoingBattleAnim;
+extern bool8 gBattleSpeedDoubleTickActive;
+extern bool8 gBattleCaptureSuccessActive;
+
+// Max frames to wait for cry at 2x speed before proceeding (cry continues in background)
+#define BATTLE_SPEED_CRY_WAIT_FRAMES 30
 extern u32 gTransformedPersonalities[MAX_BATTLERS_COUNT];
 extern u8 gPlayerDpadHoldFrames;
 extern struct BattleSpriteData *gBattleSpritesDataPtr;

--- a/include/global.h
+++ b/include/global.h
@@ -573,6 +573,7 @@ struct SaveBlock2
               u16 optionsFontType:1;
               u8 shinySeen[NUM_DEX_FLAG_BYTES]; // Tracks whether trainer has ever seen/caught a shiny of each species
               u16 optionsCursorMemory:1;
+              u16 optionsBattleSpeed:1; // 0 = normal, 1 = double speed animations/bars
 }; // sizeof=0xF2C + NUM_DEX_FLAG_BYTES
 
 extern struct SaveBlock2 *gSaveBlock2Ptr;

--- a/src/battle_anim_throw.c
+++ b/src/battle_anim_throw.c
@@ -1321,6 +1321,7 @@ static void SpriteCB_Ball_Capture_Step(struct Sprite *sprite)
     else if (sprite->sTimer == 95)
     {
         gDoingBattleAnim = FALSE;
+        gBattleCaptureSuccessActive = TRUE;
         UpdateOamPriorityInAllHealthboxes(1);
         m4aMPlayAllStop();
         if (gSaveBlock2Ptr->optionsSoundEffects == 0)

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -320,21 +320,35 @@ static void Intro_TryShinyAnimShowHealthbox(void)
 
     if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].waitForCry
         && gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].healthboxSlideInStarted
-        && !gBattleSpritesDataPtr->healthBoxesData[BATTLE_PARTNER(gActiveBattler)].waitForCry
-        && !IsCryPlayingOrClearCrySongs())
+        && !gBattleSpritesDataPtr->healthBoxesData[BATTLE_PARTNER(gActiveBattler)].waitForCry)
     {
-        if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].bgmRestored)
+        bool8 cryDone;
+        if (gSaveBlock2Ptr->optionsBattleSpeed)
         {
-            if (gBattleTypeFlags & BATTLE_TYPE_MULTI && gBattleTypeFlags & BATTLE_TYPE_LINK)
-            {
-                if (GetBattlerPosition(gActiveBattler) == 1)
-                    m4aMPlayContinue(&gMPlayInfo_BGM);
-            }
-            else
-                m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 0x100);
+            gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].introEndDelay++;
+            cryDone = !IsCryPlaying() || gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].introEndDelay >= BATTLE_SPEED_CRY_WAIT_FRAMES;
         }
-        gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].bgmRestored = TRUE;
-        bgmRestored = TRUE;
+        else
+        {
+            cryDone = !IsCryPlayingOrClearCrySongs();
+        }
+
+        if (cryDone)
+        {
+            gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].introEndDelay = 0;
+            if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].bgmRestored)
+            {
+                if (gBattleTypeFlags & BATTLE_TYPE_MULTI && gBattleTypeFlags & BATTLE_TYPE_LINK)
+                {
+                    if (GetBattlerPosition(gActiveBattler) == 1)
+                        m4aMPlayContinue(&gMPlayInfo_BGM);
+                }
+                else
+                    m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 0x100);
+            }
+            gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].bgmRestored = TRUE;
+            bgmRestored = TRUE;
+        }
     }
 
     if (!IsDoubleBattle() || (IsDoubleBattle() && (gBattleTypeFlags & BATTLE_TYPE_MULTI)))
@@ -460,7 +474,8 @@ static void SwitchIn_ShowSubstitute(void)
 
 static void SwitchIn_HandleSoundAndEnd(void)
 {
-    if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].specialAnimActive && !IsCryPlayingOrClearCrySongs())
+    if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].specialAnimActive
+        && (gSaveBlock2Ptr->optionsBattleSpeed || !IsCryPlayingOrClearCrySongs()))
     {
         if (gSprites[gBattlerSpriteIds[gActiveBattler]].callback == SpriteCallbackDummy
          || gSprites[gBattlerSpriteIds[gActiveBattler]].callback == SpriteCallbackDummy_2)

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -1241,18 +1241,32 @@ static void Intro_TryShinyAnimShowHealthbox(void)
     // Restore bgm after cry has played and healthbox anim is started
     if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].waitForCry
         && gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].healthboxSlideInStarted
-        && !gBattleSpritesDataPtr->healthBoxesData[BATTLE_PARTNER(gActiveBattler)].waitForCry
-        && !IsCryPlayingOrClearCrySongs())
+        && !gBattleSpritesDataPtr->healthBoxesData[BATTLE_PARTNER(gActiveBattler)].waitForCry)
     {
-        if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].bgmRestored)
+        bool8 cryDone;
+        if (gSaveBlock2Ptr->optionsBattleSpeed)
         {
-            if (gBattleTypeFlags & BATTLE_TYPE_MULTI && gBattleTypeFlags & BATTLE_TYPE_LINK)
-                m4aMPlayContinue(&gMPlayInfo_BGM);
-            else
-                m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 0x100);
+            gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].introEndDelay++;
+            cryDone = !IsCryPlaying() || gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].introEndDelay >= BATTLE_SPEED_CRY_WAIT_FRAMES;
         }
-        gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].bgmRestored = TRUE;
-        bgmRestored = TRUE;
+        else
+        {
+            cryDone = !IsCryPlayingOrClearCrySongs();
+        }
+
+        if (cryDone)
+        {
+            gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].introEndDelay = 0;
+            if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].bgmRestored)
+            {
+                if (gBattleTypeFlags & BATTLE_TYPE_MULTI && gBattleTypeFlags & BATTLE_TYPE_LINK)
+                    m4aMPlayContinue(&gMPlayInfo_BGM);
+                else
+                    m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 0x100);
+            }
+            gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].bgmRestored = TRUE;
+            bgmRestored = TRUE;
+        }
     }
 
     // Wait for battler anims
@@ -1319,12 +1333,20 @@ static void SwitchIn_CleanShinyAnimShowSubstitute(void)
 
 static void SwitchIn_HandleSoundAndEnd(void)
 {
-    if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].specialAnimActive
-        && !IsCryPlayingOrClearCrySongs())
+    if (!gBattleSpritesDataPtr->healthBoxesData[gActiveBattler].specialAnimActive)
     {
-        m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 0x100);
-        HandleLowHpMusicChange(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], gActiveBattler);
-        PlayerBufferExecCompleted();
+        bool8 cryDone;
+        if (gSaveBlock2Ptr->optionsBattleSpeed)
+            cryDone = TRUE; // Don't wait for cry on mid-battle switches at 2x
+        else
+            cryDone = !IsCryPlayingOrClearCrySongs();
+
+        if (cryDone)
+        {
+            m4aMPlayVolumeControl(&gMPlayInfo_BGM, TRACKS_ALL, 0x100);
+            HandleLowHpMusicChange(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], gActiveBattler);
+            PlayerBufferExecCompleted();
+        }
     }
 }
 

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -236,7 +236,7 @@ static void Intro_WaitForHealthbox(void)
         }
     }
 
-    if (IsCryPlayingOrClearCrySongs())
+    if (!gSaveBlock2Ptr->optionsBattleSpeed && IsCryPlayingOrClearCrySongs())
         finished = FALSE;
 
     if (finished)

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -251,6 +251,8 @@ EWRAM_DATA u16 gLastThrownBall = 0;
 EWRAM_DATA u16 gBallToDisplay = 0;
 EWRAM_DATA bool8 gLastUsedBallMenuPresent = FALSE;
 EWRAM_DATA u8 gItemLimit = 0;
+EWRAM_DATA bool8 gBattleSpeedDoubleTickActive = FALSE;
+EWRAM_DATA bool8 gBattleCaptureSuccessActive = FALSE;
 
 void (*gPreBattleCallback1)(void);
 void (*gBattleMainFunc)(void);
@@ -2130,6 +2132,34 @@ void BattleMainCB2(void)
     UpdatePaletteFade();
     RunTasks();
 
+    if (gSaveBlock2Ptr->optionsBattleSpeed
+        && !(gBattleTypeFlags & BATTLE_TYPE_LINK)
+        && !gBattleCaptureSuccessActive)
+    {
+        bool8 ballActive = FALSE;
+        u8 i;
+        for (i = 0; i < gBattlersCount; i++)
+        {
+            if (gBattleSpritesDataPtr->healthBoxesData[i].ballAnimActive
+             || gBattleSpritesDataPtr->healthBoxesData[i].waitForCry)
+            {
+                ballActive = TRUE;
+                break;
+            }
+        }
+
+        gBattleSpeedDoubleTickActive = TRUE;
+        if (!ballActive && gBattleMainFunc != HandleTurnActionSelectionState)
+        {
+            for (gActiveBattler = 0; gActiveBattler < gBattlersCount; gActiveBattler++)
+                gBattlerControllerFuncs[gActiveBattler]();
+        }
+        AnimateSprites();
+        BuildOamBuffer();
+        RunTasks();
+        gBattleSpeedDoubleTickActive = FALSE;
+    }
+
     if (JOY_HELD(B_BUTTON) && gBattleTypeFlags & BATTLE_TYPE_RECORDED && RecordedBattle_CanStopPlayback())
     {
         // Player pressed B during recorded battle playback, end battle
@@ -2145,6 +2175,7 @@ static void FreeRestoreBattleData(void)
     gMain.callback1 = gPreBattleCallback1;
     gScanlineEffect.state = 3;
     gMain.inBattle = FALSE;
+    gBattleCaptureSuccessActive = FALSE;
     ZeroEnemyPartyMons();
     m4aSongNumStop(SE_LOW_HEALTH);
     FreeMonSpritesGfx();

--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -1093,6 +1093,8 @@ static void LaunchBattleTransitionTask(u8 transitionId)
 static void Task_BattleTransition(u8 taskId)
 {
     while (sTaskHandlers[gTasks[taskId].tState](&gTasks[taskId]));
+    if (gSaveBlock2Ptr->optionsBattleSpeed)
+        while (sTaskHandlers[gTasks[taskId].tState](&gTasks[taskId]));
 }
 
 static bool8 Transition_StartIntro(struct Task *task)

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -109,6 +109,7 @@ static void SetDefaultOptions(void)
     gSaveBlock2Ptr->optionsFishing = 1;
     gSaveBlock2Ptr->optionsFastIntro = 1;
     gSaveBlock2Ptr->optionsFastBattle = 1;
+    gSaveBlock2Ptr->optionsBattleSpeed = 0;
     gSaveBlock2Ptr->optionsBikeMusic = 0;
     gSaveBlock2Ptr->optionsEvenFasterJoy = 1;
     gSaveBlock2Ptr->optionsSurfMusic = 0;

--- a/src/options_plus_menu.c
+++ b/src/options_plus_menu.c
@@ -59,6 +59,7 @@ enum
     MENUITEM_BATTLE_SPLIT,
     MENUITEM_BATTLE_FAST_INTRO,
     MENUITEM_BATTLE_FAST_BATTLES,
+    MENUITEM_BATTLE_BATTLE_SPEED,
     MENUITEM_BATTLE_CURSOR_MEMORY,
     MENUITEM_BATTLE_NEW_BACKGROUNDS,
     MENUITEM_BATTLE_BALL_PROMPT,
@@ -209,6 +210,7 @@ static void DrawChoices_TypeEffective(int selection, int y);
 static void DrawChoices_Fishing(int selection, int y);
 static void DrawChoices_FastIntro(int selection, int y);
 static void DrawChoices_FastBattles(int selection, int y);
+static void DrawChoices_BattleSpeed(int selection, int y);
 static void DrawChoices_BikeMusic(int selection, int y);
 static void DrawChoices_EvenFasterJoy(int selection, int y);
 static void DrawChoices_SurfMusic(int selection, int y);
@@ -290,6 +292,7 @@ struct // MENU_CUSTOM
     [MENUITEM_BATTLE_SPLIT]            = {DrawChoices_Style,              ProcessInput_Options_Two},
     [MENUITEM_BATTLE_TYPE_EFFECTIVE]   = {DrawChoices_TypeEffective,      ProcessInput_Options_Two},
     [MENUITEM_BATTLE_FAST_BATTLES]     = {DrawChoices_FastBattles,        ProcessInput_Options_Two},
+    [MENUITEM_BATTLE_BATTLE_SPEED]     = {DrawChoices_BattleSpeed,        ProcessInput_Options_Two},
     [MENUITEM_BATTLE_RUN_TYPE]         = {DrawChoices_Run_Type,           ProcessInput_Options_Four},
     [MENUITEM_BATTLE_LR_RUN]           = {DrawChoices_LR_Run,             ProcessInput_Options_Two},
     [MENUITEM_BATTLE_BALL_PROMPT]      = {DrawChoices_Ball_Prompt,        ProcessInput_Options_Two},
@@ -319,6 +322,7 @@ static const u8 sText_OptionFishing[]             = _("EASIER FISHING");
 static const u8 sText_OptionFastIntro[]           = _("FAST INTRO");
 static const u8 sText_OptionLargeFollower[]       = _("BIG FOLLOWERS");
 static const u8 sText_OptionFastBattles[]         = _("FAST BATTLES");
+static const u8 sText_OptionBattleSpeed[]         = _("ANIM SPEED");
 static const u8 sText_OptionEvenFasterJoy[]       = _("EVEN FASTER JOY");
 static const u8 sText_OptionSkipIntro[]           = _("SKIP INTRO");
 static const u8 sText_OptionLR_Run[]              = _("RUN PROMPT");
@@ -359,6 +363,7 @@ static const u8 *const sOptionMenuItemsNamesCustom[MENUITEM_BATTLE_COUNT] =
     [MENUITEM_BATTLE_SPLIT]            = gText_OptionStyle,
     [MENUITEM_BATTLE_TYPE_EFFECTIVE]   = sText_OptionTypeEffective,
     [MENUITEM_BATTLE_FAST_BATTLES]     = sText_OptionFastBattles,
+    [MENUITEM_BATTLE_BATTLE_SPEED]     = sText_OptionBattleSpeed,
     [MENUITEM_BATTLE_RUN_TYPE]         = sText_OptionRunType,
     [MENUITEM_BATTLE_LR_RUN]           = sText_OptionLR_Run,
     [MENUITEM_BATTLE_BALL_PROMPT]      = sText_OptionBallPrompt,
@@ -431,6 +436,7 @@ static bool8 CheckConditions(int selection)
         case MENUITEM_BATTLE_SPLIT:           return TRUE;
         case MENUITEM_BATTLE_TYPE_EFFECTIVE:  return TRUE;
         case MENUITEM_BATTLE_FAST_BATTLES:    return TRUE;
+        case MENUITEM_BATTLE_BATTLE_SPEED:    return TRUE;
         case MENUITEM_BATTLE_RUN_TYPE:        return TRUE;
         case MENUITEM_BATTLE_LR_RUN:          return sOptions->sel_battle[MENUITEM_BATTLE_RUN_TYPE] == 1 || sOptions->sel_battle[MENUITEM_BATTLE_RUN_TYPE] == 3;
         case MENUITEM_BATTLE_BALL_PROMPT:     return TRUE;
@@ -521,6 +527,8 @@ static const u8 sText_Desc_FastIntroOn[]           = _("Skip the sliding animati
 static const u8 sText_Desc_FastIntroOff[]          = _("Battles load at the usual speed.");
 static const u8 sText_Desc_FastBattleOn[]          = _("Skips all delays in battles, which\nmakes them faster.");
 static const u8 sText_Desc_FastBattleOff[]         = _("Manual delay skipping. You can\npress A or B to skip delays.");
+static const u8 sText_Desc_BattleSpeedOn[]         = _("Battle animations play at\nnormal speed.");
+static const u8 sText_Desc_BattleSpeedOff[]        = _("Doubles the speed of HP bars, EXP,\nanims, faints, and switches.");
 static const u8 sText_Desc_Run_Type_Off[]          = _("No quick running from battles.");
 static const u8 sText_Desc_Run_Type_LR[]           = _("Hold {L_BUTTON}+{R_BUTTON}, then {A_BUTTON} to run from\nbattles before they start.");
 static const u8 sText_Desc_Run_Type_B[]            = _("Press {B_BUTTON} to move the cursor to the Run\noption after the battle started.");
@@ -539,6 +547,7 @@ static const u8 *const sOptionMenuItemDescriptionsCustom[MENUITEM_BATTLE_COUNT][
     [MENUITEM_BATTLE_BATTLESTYLE]         = {sText_Desc_BattleStyle_Shift,        sText_Desc_BattleStyle_Set,        sText_Empty},
     [MENUITEM_BATTLE_FAST_INTRO]          = {sText_Desc_FastIntroOn,              sText_Desc_FastIntroOff},
     [MENUITEM_BATTLE_FAST_BATTLES]        = {sText_Desc_FastBattleOn,             sText_Desc_FastBattleOff},
+    [MENUITEM_BATTLE_BATTLE_SPEED]        = {sText_Desc_BattleSpeedOn,            sText_Desc_BattleSpeedOff},
     [MENUITEM_BATTLE_SPLIT]               = {sText_Desc_StyleOn,                  sText_Desc_StyleOff},
     [MENUITEM_BATTLE_TYPE_EFFECTIVE]      = {sText_Desc_TypeEffectiveOn,          sText_Desc_TypeEffectiveOff},
     [MENUITEM_BATTLE_LR_RUN]              = {sText_Desc_LR_Run_On,                sText_Desc_LR_Run_Off},
@@ -608,6 +617,7 @@ static const u8 *const sOptionMenuItemDescriptionsDisabledCustom[MENUITEM_BATTLE
     [MENUITEM_BATTLE_BATTLESTYLE]         = sText_Empty,
     [MENUITEM_BATTLE_FAST_INTRO]          = sText_Empty,
     [MENUITEM_BATTLE_FAST_BATTLES]        = sText_Empty,
+    [MENUITEM_BATTLE_BATTLE_SPEED]        = sText_Empty,
     [MENUITEM_BATTLE_SPLIT]               = sText_Empty,
     [MENUITEM_BATTLE_TYPE_EFFECTIVE]      = sText_Empty,
     [MENUITEM_BATTLE_LR_RUN]              = sText_Desc_Disabled_LR_Run,
@@ -885,6 +895,7 @@ void CB2_InitOptionPlusMenu(void)
         sOptions->sel_battle[MENUITEM_BATTLE_BATTLESCENE]       = gSaveBlock2Ptr->optionsBattleSceneOff;
         sOptions->sel_battle[MENUITEM_BATTLE_FAST_INTRO]        = gSaveBlock2Ptr->optionsFastIntro;
         sOptions->sel_battle[MENUITEM_BATTLE_FAST_BATTLES]      = gSaveBlock2Ptr->optionsFastBattle;
+        sOptions->sel_battle[MENUITEM_BATTLE_BATTLE_SPEED]      = gSaveBlock2Ptr->optionsBattleSpeed;
         sOptions->sel_battle[MENUITEM_BATTLE_SPLIT]             = gSaveBlock2Ptr->optionStyle;
         sOptions->sel_battle[MENUITEM_BATTLE_TYPE_EFFECTIVE]    = gSaveBlock2Ptr->optionTypeEffective;
         sOptions->sel_battle[MENUITEM_BATTLE_LR_RUN]            = gSaveBlock2Ptr->optionsLRtoRun;
@@ -1124,6 +1135,7 @@ static void Task_OptionMenuSave(u8 taskId)
     gSaveBlock2Ptr->optionsBattleSceneOff   = sOptions->sel_battle[MENUITEM_BATTLE_BATTLESCENE];
     gSaveBlock2Ptr->optionsFastIntro        = sOptions->sel_battle[MENUITEM_BATTLE_FAST_INTRO];
     gSaveBlock2Ptr->optionsFastBattle       = sOptions->sel_battle[MENUITEM_BATTLE_FAST_BATTLES];
+    gSaveBlock2Ptr->optionsBattleSpeed      = sOptions->sel_battle[MENUITEM_BATTLE_BATTLE_SPEED];
     gSaveBlock2Ptr->optionStyle             = sOptions->sel_battle[MENUITEM_BATTLE_SPLIT];
     gSaveBlock2Ptr->optionTypeEffective     = sOptions->sel_battle[MENUITEM_BATTLE_TYPE_EFFECTIVE];
     gSaveBlock2Ptr->optionsLRtoRun          = sOptions->sel_battle[MENUITEM_BATTLE_LR_RUN];
@@ -1410,9 +1422,9 @@ static void ReDrawAll(void)
     }
     else
     {
-        if (sOptions->arrowTaskId == TASK_NONE)
-            sOptions->arrowTaskId = sOptions->arrowTaskId = AddScrollIndicatorArrowPairParameterized(SCROLL_ARROW_UP, 240 / 2, 20, 110, MenuItemCount() - 1, 110, 110, 0);
-
+        if (sOptions->arrowTaskId != TASK_NONE)
+            RemoveScrollIndicatorArrowPair(sOptions->arrowTaskId);
+        sOptions->arrowTaskId = AddScrollIndicatorArrowPairParameterized(SCROLL_ARROW_UP, 240 / 2, 20, 110, MenuItemCount() - 1, 110, 110, 0);
     }
 
     FillWindowPixelBuffer(WIN_OPTIONS, PIXEL_FILL(1));
@@ -1817,6 +1829,28 @@ static void DrawChoices_FastBattles(int selection, int y)
 
     DrawOptionMenuChoice(gText_BattleSceneOn, 104, y, styles[0], active);
     DrawOptionMenuChoice(gText_BattleSceneOff, GetStringRightAlignXOffset(1, gText_BattleSceneOff, 198), y, styles[1], active);
+}
+
+static const u8 sText_BattleSpeed1x[] = _("1x");
+static const u8 sText_BattleSpeed2x[] = _("2x");
+
+static void DrawChoices_BattleSpeed(int selection, int y)
+{
+    bool8 active = CheckConditions(MENUITEM_BATTLE_BATTLE_SPEED);
+    u8 styles[2] = {0};
+    styles[selection] = 1;
+
+    if (selection == 0)
+    {
+        gSaveBlock2Ptr->optionsBattleSpeed = 0; // 1x (normal)
+    }
+    else
+    {
+        gSaveBlock2Ptr->optionsBattleSpeed = 1; // 2x (double speed)
+    }
+
+    DrawOptionMenuChoice(sText_BattleSpeed1x, 104, y, styles[0], active);
+    DrawOptionMenuChoice(sText_BattleSpeed2x, GetStringRightAlignXOffset(1, sText_BattleSpeed2x, 198), y, styles[1], active);
 }
 
 static void DrawChoices_BikeMusic(int selection, int y)

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "overworld.h"
+#include "battle.h"
 #include "battle_pyramid.h"
 #include "battle_setup.h"
 #include "berry.h"
@@ -1696,6 +1697,14 @@ static void OverworldBasic(void)
 void CB2_OverworldBasic(void)
 {
     OverworldBasic();
+    if (gSaveBlock2Ptr->optionsBattleSpeed && !IsCryPlaying())
+    {
+        gBattleSpeedDoubleTickActive = TRUE;
+        RunTasks();
+        AnimateSprites();
+        BuildOamBuffer();
+        gBattleSpeedDoubleTickActive = FALSE;
+    }
 }
 
 void CB2_Overworld(void)

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -692,6 +692,10 @@ static void Task_PlayCryWhenReleasedFromBall(u8 taskId)
             PlayCry_ByMode(species, pan, CRY_MODE_NORMAL);
         else
             PlayCry_ByMode(species, pan, CRY_MODE_WEAK);
+        gTasks[taskId].tCryTaskState = 10;
+        break;
+    case 10:
+        // Wait one frame so cry registers as playing before clearing flag
         gBattleSpritesDataPtr->healthBoxesData[battlerId].waitForCry = FALSE;
         DestroyTask(taskId);
         break;
@@ -709,13 +713,17 @@ static void Task_PlayCryWhenReleasedFromBall(u8 taskId)
             else
                 PlayCry_ReleaseDouble(species, pan, CRY_MODE_WEAK_DOUBLES);
 
-            gBattleSpritesDataPtr->healthBoxesData[battlerId].waitForCry = FALSE;
-            DestroyTask(taskId);
+            gTasks[taskId].tCryTaskState = 21;
         }
         else
         {
             gTasks[taskId].tCryTaskFrames--;
         }
+        break;
+    case 21:
+        // Wait one frame so cry registers as playing before clearing flag
+        gBattleSpritesDataPtr->healthBoxesData[battlerId].waitForCry = FALSE;
+        DestroyTask(taskId);
         break;
     case 3:
         gTasks[taskId].tCryTaskFrames = 6;
@@ -749,6 +757,10 @@ static void Task_PlayCryWhenReleasedFromBall(u8 taskId)
         else
             PlayCry_ReleaseDouble(species, pan, CRY_MODE_WEAK);
 
+        gTasks[taskId].tCryTaskState = 33;
+        break;
+    case 33:
+        // Wait one frame so cry registers as playing before clearing flag
         gBattleSpritesDataPtr->healthBoxesData[battlerId].waitForCry = FALSE;
         DestroyTask(taskId);
         break;


### PR DESCRIPTION
Would love more eyes on this and some testing.  I modeled it after other hacks that do a smooth 2x/4x battle speed options.
You may wonder 
- why do this when emulators can do this?"  besides respecting OG hardware, those emulators also speed up the audio, which usually sounds awful.  Also, lower power emulator handhelds can't speedup the game much more than 1.3-1.4x, but the game can easily speed this up.
- we can turn off battle animations?  yes - another great grinding option to combine, even.   this allows you to enjoy the full animation sequence with increased speed and normal audio.

**Description:**

Adds a **BATTLE SPEED** setting (1x / 2x) to the Battle Options menu. When set to 2x, battles play at double speed with the following affected:

- HP bar drain/fill
- EXP bar gain
- Battle move animations
- Faint/KO animations
- Switch-in / switch-out animations
- Status effect animations (poison, sleep, etc.)
- Weather/buff animations
- Stat change animations
- Battle transition (overworld → battle screen wipe)
- Script pauses and delays

**Not affected:** Text print speed, palette fades, AI thinking time, player input menus.

**Implementation:**
- Double-ticks `AnimateSprites()`, `RunTasks()`, and `gBattlerControllerFuncs` per frame in `BattleMainCB2`
- Battle transition (`CB2_OverworldBasic`) also double-ticked via separate hook

**Safety guards:**
- Link battles excluded entirely (desync risk)
- Controller double-tick paused during player action/move/target selection (prevents input doubling)
- Controller double-tick paused while ball animations are active or cry is pending
- Cry task uses 1-frame delay before clearing `waitForCry` flag (prevents cry being skipped due to m4a mixer latency)
- `optionsBattleSpeed` placed at end of SaveBlock2 struct for existing save compatibility (defaults to 0/1x)

if battle animations are turned off, we still get acceleration:

-   HP bars drain at 2x
-   EXP bars fill at 2x
-   Faint slide animations at 2x
-   Switch-in/out (pokeball throw, mon appearing) at 2x
-   Stat change animations at 2x (these still play with anims off)
-   Weather continuing animations at 2x (these also still play)
-   Script pauses/delays at 2x
-   Battle transition at 2x
