### PR TITLE
fix: skip 2nd Pokemon action on forfeit confirmation in doubles

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -5288,6 +5288,19 @@ static void HandleTurnActionSelectionState(void)
                     gHitMarker |= HITMARKER_RUN;
                     gChosenActionByBattler[gActiveBattler] = B_ACTION_RUN;
                     gBattleCommunication[gActiveBattler] = STATE_WAIT_ACTION_CONFIRMED_STANDBY;
+
+                    // In doubles, also forfeit for the partner so the battle ends immediately
+                    if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
+                    {
+                        u8 partner = GetBattlerAtPosition(BATTLE_PARTNER(GetBattlerPosition(gActiveBattler)));
+                        gChosenActionByBattler[partner] = B_ACTION_RUN;
+                        gBattleCommunication[partner] = STATE_WAIT_ACTION_CONFIRMED;
+
+                        // Skip opponent AI and go straight to turn execution
+                        gBattlerAttacker = gActiveBattler;
+                        gBattleOutcome = B_OUTCOME_FORFEITED;
+                        gBattleMainFunc = HandleEndTurn_RanFromBattle;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
**Description:**

Fixes an issue where confirming a forfeit in double battle formats (Frontier/Trainer Hill) would still prompt for the 2nd Pokemon's action instead of ending the battle immediately.

**Changes:**
- When forfeit is confirmed via `BattleScript_AskIfWantsToForfeitMatch`, the partner battler's action is set to RUN and the battle jumps directly to `HandleEndTurn_RanFromBattle`
- Bypasses opponent AI computation and turn ordering since they're irrelevant on forfeit
- Only affects `BATTLE_TYPE_FRONTIER` and `BATTLE_TYPE_TRAINER_HILL` double battles (the only formats where the forfeit prompt exists)

**Does not affect:**
- Normal trainer battles ("Can't run" message still works)
- Singles forfeits (already worked correctly)
- Wild battle running
- Post-battle evolution/results (handled by `HandleEndTurn_FinishBattle` which still runs normally)