### PR TITLE
feat: add Brighter Nights option

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -573,6 +573,8 @@ struct SaveBlock2
               u16 optionsFontType:1;
               u8 shinySeen[NUM_DEX_FLAG_BYTES]; // Tracks whether trainer has ever seen/caught a shiny of each species
               u16 optionsCursorMemory:1;
+              u16 optionsBattleSpeed:1; // 0 = normal, 1 = double speed animations/bars
+              u16 optionsBrighterNights:1; // 0 = normal darkness, 1 = brighter nights
 }; // sizeof=0xF2C + NUM_DEX_FLAG_BYTES
 
 extern struct SaveBlock2 *gSaveBlock2Ptr;

--- a/include/overworld.h
+++ b/include/overworld.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_OVERWORLD_H
 #define GUARD_OVERWORLD_H
 
+struct BlendSettings;
+
 #define LINK_KEY_CODE_NULL 0x00
 #define LINK_KEY_CODE_EMPTY 0x11
 #define LINK_KEY_CODE_DPAD_DOWN 0x12
@@ -147,6 +149,7 @@ void CB1_Overworld(void);
 void CB2_OverworldBasic(void);
 u8 UpdateTimeOfDay(void);
 bool8 MapHasNaturalLight(u8 mapType);
+const struct BlendSettings *GetTimeOfDayBlend(void);
 void UpdateAltBgPalettes(u16 palettes);
 void UpdatePalettesWithTime(u32);
 void CB2_Overworld(void);

--- a/src/battle_bg.c
+++ b/src/battle_bg.c
@@ -1267,6 +1267,15 @@ void DrawMainBattleBackground(void)
             break;
         }
     }
+
+    // Brighten battle terrain night palettes when Bright Nights is on
+    if (gSaveBlock2Ptr->optionsBrighterNights
+        && !(gMapHeader.mapType == MAP_TYPE_INDOOR)
+        && ((gLocalTime.hours >= 0 && gLocalTime.hours < 6) || (gLocalTime.hours >= 21 && gLocalTime.hours < 24)))
+    {
+        // Blend BG palettes 2-4 (terrain) toward a warm dark tone to lift blacks without hazing
+        BlendPalettes(0x1C, 3, RGB(10, 10, 14));
+    }
 }
 
 void LoadBattleTextboxAndBackground(void)

--- a/src/field_weather.c
+++ b/src/field_weather.c
@@ -808,8 +808,8 @@ void FadeScreen(u8 mode, s8 delay)
           if (MapHasNaturalLight(gMapHeader.mapType)) {
             UpdateAltBgPalettes(PALETTES_BG);
             BeginTimeOfDayPaletteFade(PALETTES_ALL, delay, 16, 0,
-              (struct BlendSettings *)&gTimeOfDayBlend[currentTimeBlend.time0],
-              (struct BlendSettings *)&gTimeOfDayBlend[currentTimeBlend.time1],
+              (struct BlendSettings *)&GetTimeOfDayBlend()[currentTimeBlend.time0],
+              (struct BlendSettings *)&GetTimeOfDayBlend()[currentTimeBlend.time1],
               currentTimeBlend.weight, fadeColor);
           } else {
             BeginNormalPaletteFade(PALETTES_ALL, delay, 16, 0, fadeColor);

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -125,6 +125,7 @@ static void SetDefaultOptions(void)
     gSaveBlock2Ptr->optionsRunType = 1;
     gSaveBlock2Ptr->optionsSurfOverworld = 0;
     gSaveBlock2Ptr->optionsCursorMemory = 1;
+    gSaveBlock2Ptr->optionsBrighterNights = 0;
 }
 
 static void ClearPokedexFlags(void)

--- a/src/options_plus_menu.c
+++ b/src/options_plus_menu.c
@@ -48,6 +48,7 @@ enum
     MENUITEM_MAIN_UNIT_TYPE,
     MENUITEM_MAIN_SKIP_INTRO,
     MENUITEM_MAIN_FRAMETYPE,
+    MENUITEM_MAIN_BRIGHTER_NIGHTS,
     MENUITEM_MAIN_COUNT,
 };
 
@@ -226,6 +227,7 @@ static void DrawChoices_Run_Type(int selection, int y);
 static void DrawChoices_Autorun_Surf(int selection, int y);
 static void DrawChoices_Autorun_Dive(int selection, int y);
 static void DrawChoices_SurfOverworld(int selection, int y);
+static void DrawChoices_BrighterNights(int selection, int y);
 static void DrawChoices_Font(int selection, int y);
 static void DrawChoices_CursorMemory(int selection, int y);
 static void DrawBgWindowFrames(void);
@@ -275,6 +277,7 @@ struct // MENU_MAIN
     [MENUITEM_MAIN_SKIP_INTRO]              = {DrawChoices_Skip_Intro,       ProcessInput_Options_Two},
     [MENUITEM_MAIN_UNIT_TYPE]               = {DrawChoices_Unit_Type,        ProcessInput_Options_Two},
     [MENUITEM_MAIN_FRAMETYPE]               = {DrawChoices_FrameType,        ProcessInput_FrameType},
+    [MENUITEM_MAIN_BRIGHTER_NIGHTS]         = {DrawChoices_BrighterNights,   ProcessInput_Options_Two},
     [MENUITEM_MAIN_SURFOVERWORLD]           = {DrawChoices_SurfOverworld,    ProcessInput_Options_Two},
 };
 
@@ -329,6 +332,7 @@ static const u8 sText_OptionRunType[]             = _("QUICK RUN");
 static const u8 sText_AutorunEnable_Surf[]        = _("AUTORUN (SURF)");
 static const u8 sText_AutorunEnable_Dive[]        = _("AUTORUN (DIVE)");
 static const u8 sText_SurfSprites[]               = _("SURF SPRITES");
+static const u8 sText_BrighterNights[]            = _("BRIGHT NIGHTS");
 static const u8 sText_FontType[]                  = _("FONT TYPE");
 static const u8 *const sOptionMenuItemsNamesMain[MENUITEM_MAIN_COUNT] =
 {
@@ -347,6 +351,7 @@ static const u8 *const sOptionMenuItemsNamesMain[MENUITEM_MAIN_COUNT] =
     [MENUITEM_MAIN_SKIP_INTRO]          = sText_OptionSkipIntro,
     [MENUITEM_MAIN_UNIT_TYPE]           = sText_OptionUnitType,
     [MENUITEM_MAIN_FRAMETYPE]           = gText_Frame,
+    [MENUITEM_MAIN_BRIGHTER_NIGHTS]     = sText_BrighterNights,
     [MENUITEM_MAIN_SURFOVERWORLD]       = sText_SurfSprites,
 };
 
@@ -421,6 +426,7 @@ static bool8 CheckConditions(int selection)
         case MENUITEM_MAIN_SKIP_INTRO:        return TRUE;
         case MENUITEM_MAIN_UNIT_TYPE:         return TRUE;
         case MENUITEM_MAIN_SURFOVERWORLD:     return TRUE;
+        case MENUITEM_MAIN_BRIGHTER_NIGHTS:   return TRUE;
         }
     case MENU_CUSTOM:
         switch(selection)
@@ -492,6 +498,8 @@ static const u8 sText_Desc_Units_Imperial[]        = _("Display Berry and Pokém
 static const u8 sText_Desc_Units_Metric[]          = _("Display Berry and Pokémon weight\nand size in kilograms and meters.");
 static const u8 sText_Desc_SurfOverworldDynamic[]       = _("Use the Pokémon's sprite when\nsurfing.");
 static const u8 sText_Desc_SurfOverworldOriginal[]      = _("Use the original generic sprite when\nsurfing.");
+static const u8 sText_Desc_BrighterNightsOn[]           = _("Night shading is less dark.\nEasier to see at night.");
+static const u8 sText_Desc_BrighterNightsOff[]          = _("Night shading at full darkness.\nOriginal intensity.");
 static const u8 *const sOptionMenuItemDescriptionsMain[MENUITEM_MAIN_COUNT][3] =
 {
     [MENUITEM_MAIN_TEXTSPEED]         = {sText_Desc_TextSpeed,            sText_Empty,                     sText_Empty},
@@ -510,6 +518,7 @@ static const u8 *const sOptionMenuItemDescriptionsMain[MENUITEM_MAIN_COUNT][3] =
     [MENUITEM_MAIN_SKIP_INTRO]        = {sText_Desc_SkipIntroOn,          sText_Desc_SkipIntroOff},
     [MENUITEM_MAIN_UNIT_TYPE]         = {sText_Desc_Units_Metric,         sText_Desc_Units_Imperial},
     [MENUITEM_MAIN_SURFOVERWORLD]     = {sText_Desc_SurfOverworldDynamic, sText_Desc_SurfOverworldOriginal},
+    [MENUITEM_MAIN_BRIGHTER_NIGHTS]   = {sText_Desc_BrighterNightsOff,     sText_Desc_BrighterNightsOn},
 };
 
 // Custom {PKMN}
@@ -598,6 +607,7 @@ static const u8 *const sOptionMenuItemDescriptionsDisabledMain[MENUITEM_MAIN_COU
     [MENUITEM_MAIN_EVEN_FASTER_JOY]   = sText_Empty,
     [MENUITEM_MAIN_SKIP_INTRO]        = sText_Empty,
     [MENUITEM_MAIN_SURFOVERWORLD]     = sText_Empty,
+    [MENUITEM_MAIN_BRIGHTER_NIGHTS]   = sText_Empty,
 };
 
 // Disabled Custom
@@ -715,9 +725,10 @@ static void DrawTopBarText(void)
 static void DrawOptionMenuTexts(void) //left side text
 {
     u8 i;
+    u8 optionsToDraw = min(OPTIONS_ON_SCREEN, MenuItemCount());
 
     FillWindowPixelBuffer(WIN_OPTIONS, PIXEL_FILL(1));
-    for (i = 0; i < MenuItemCount(); i++)
+    for (i = 0; i < optionsToDraw; i++)
         DrawLeftSideOptionText(i, (i * Y_DIFF) + 1);
     CopyWindowToVram(WIN_OPTIONS, COPYWIN_FULL);
 }
@@ -880,6 +891,7 @@ void CB2_InitOptionPlusMenu(void)
         sOptions->sel[MENUITEM_MAIN_SKIP_INTRO]          = gSaveBlock2Ptr->optionsSkipIntro;
         sOptions->sel[MENUITEM_MAIN_UNIT_TYPE]           = gSaveBlock2Ptr->optionsUnitSystem;
         sOptions->sel[MENUITEM_MAIN_SURFOVERWORLD]       = gSaveBlock2Ptr->optionsSurfOverworld;
+        sOptions->sel[MENUITEM_MAIN_BRIGHTER_NIGHTS]     = gSaveBlock2Ptr->optionsBrighterNights;
 
         sOptions->sel_battle[MENUITEM_BATTLE_BATTLESTYLE]       = gSaveBlock2Ptr->optionsBattleStyle;
         sOptions->sel_battle[MENUITEM_BATTLE_BATTLESCENE]       = gSaveBlock2Ptr->optionsBattleSceneOff;
@@ -1119,6 +1131,7 @@ static void Task_OptionMenuSave(u8 taskId)
     gSaveBlock2Ptr->optionsSkipIntro             = sOptions->sel[MENUITEM_MAIN_SKIP_INTRO];
     gSaveBlock2Ptr->optionsUnitSystem            = sOptions->sel[MENUITEM_MAIN_UNIT_TYPE];
     gSaveBlock2Ptr->optionsSurfOverworld         = sOptions->sel[MENUITEM_MAIN_SURFOVERWORLD];
+    gSaveBlock2Ptr->optionsBrighterNights        = sOptions->sel[MENUITEM_MAIN_BRIGHTER_NIGHTS];
 
     gSaveBlock2Ptr->optionsBattleStyle      = sOptions->sel_battle[MENUITEM_BATTLE_BATTLESTYLE];
     gSaveBlock2Ptr->optionsBattleSceneOff   = sOptions->sel_battle[MENUITEM_BATTLE_BATTLESCENE];
@@ -2075,6 +2088,25 @@ static void DrawChoices_SurfOverworld(int selection, int y)
 
     DrawOptionMenuChoice(sText_Dynamic, 104, y, styles[0], active);
     DrawOptionMenuChoice(sText_Old, GetStringRightAlignXOffset(1, sText_Old, 198), y, styles[1], active);
+}
+
+static void DrawChoices_BrighterNights(int selection, int y)
+{
+    bool8 active = CheckConditions(MENUITEM_MAIN_BRIGHTER_NIGHTS);
+    u8 styles[2] = {0};
+    styles[selection] = 1;
+
+    if (selection == 0)
+    {
+        gSaveBlock2Ptr->optionsBrighterNights = 0; // Off (original)
+    }
+    else
+    {
+        gSaveBlock2Ptr->optionsBrighterNights = 1; // On (brighter)
+    }
+
+    DrawOptionMenuChoice(gText_BattleSceneOff, 104, y, styles[0], active);
+    DrawOptionMenuChoice(gText_BattleSceneOn, GetStringRightAlignXOffset(1, gText_BattleSceneOn, 198), y, styles[1], active);
 }
 
 static const u8 sText_Em[]          = _("Emerald");

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1534,6 +1534,7 @@ void CB1_Overworld(void)
 }
 
 #define TINT_NIGHT Q_8_8(0.456) | Q_8_8(0.456) << 8 | Q_8_8(0.615) << 16
+#define TINT_NIGHT_BRIGHT Q_8_8(0.619) | Q_8_8(0.619) << 8 | Q_8_8(0.731) << 16
 
 const struct BlendSettings gTimeOfDayBlend[] =
 {
@@ -1541,6 +1542,20 @@ const struct BlendSettings gTimeOfDayBlend[] =
     [TIME_OF_DAY_TWILIGHT] = {.coeff = 4, .blendColor = 0xA8B0E0, .isTint = TRUE},
     [TIME_OF_DAY_DAY] = {.coeff = 0, .blendColor = 0},
 };
+
+const struct BlendSettings gTimeOfDayBlendBright[] =
+{
+    [TIME_OF_DAY_NIGHT] = {.coeff = 10, .blendColor = TINT_NIGHT_BRIGHT, .isTint = TRUE},
+    [TIME_OF_DAY_TWILIGHT] = {.coeff = 4, .blendColor = 0xA8B0E0, .isTint = TRUE},
+    [TIME_OF_DAY_DAY] = {.coeff = 0, .blendColor = 0},
+};
+
+const struct BlendSettings *GetTimeOfDayBlend(void)
+{
+    if (gSaveBlock2Ptr->optionsBrighterNights)
+        return gTimeOfDayBlendBright;
+    return gTimeOfDayBlend;
+}
 
 u8 UpdateTimeOfDay(void) {
     s32 hours, minutes;
@@ -1636,8 +1651,8 @@ void UpdatePalettesWithTime(u32 palettes) {
         palettes,
         gPlttBufferUnfaded,
         gPlttBufferFaded,
-        (struct BlendSettings *)&gTimeOfDayBlend[currentTimeBlend.time0],
-        (struct BlendSettings *)&gTimeOfDayBlend[currentTimeBlend.time1],
+        (struct BlendSettings *)&GetTimeOfDayBlend()[currentTimeBlend.time0],
+        (struct BlendSettings *)&GetTimeOfDayBlend()[currentTimeBlend.time1],
         currentTimeBlend.weight
     );
     }
@@ -1651,8 +1666,8 @@ u8 UpdateSpritePaletteWithTime(u8 paletteNum) {
         1,
         &gPlttBufferUnfaded[OBJ_PLTT_ID(paletteNum)],
         &gPlttBufferFaded[OBJ_PLTT_ID(paletteNum)],
-        (struct BlendSettings *)&gTimeOfDayBlend[currentTimeBlend.time0],
-        (struct BlendSettings *)&gTimeOfDayBlend[currentTimeBlend.time1],
+        (struct BlendSettings *)&GetTimeOfDayBlend()[currentTimeBlend.time0],
+        (struct BlendSettings *)&GetTimeOfDayBlend()[currentTimeBlend.time1],
         currentTimeBlend.weight
     );
     }


### PR DESCRIPTION
This is a feature for folks like me who emulate with OG hardware color corrections, and anyone on actual original hardware flashcarts/etc.  it basically reduces the endpoint of "nighttime" to about 70% of where it is, quite subtle but significant for contrast.

default will be Off, legacy saves wont see any change unless they toggle to On in Options.

**Description:**

Adds a **BRIGHT NIGHTS** toggle to the Main Options page. Reduces nighttime darkness for players on hardware/screens where the original is too dark to make out terrain, trainers, and items.

### Overworld

Night palette tint reduced to 70% of original darkness:
- OFF (original): R×0.456, G×0.456, B×0.615
- ON (brighter): R×0.619, G×0.619, B×0.731

Still distinctly nighttime with blue shift. Lit elements (windows, pokecenter signs) unaffected — they use the transparency high-bit blend path. Twilight and day palettes unchanged. Transition timing unchanged.

### Battle Backgrounds

Night terrain palettes (loaded at hours 0-6 and 21-24) receive a warm lift: blend toward RGB(10,10,14) at 3/16 strength. Lifts deep blacks without washing out or hazing. Works with both Emerald and modernized (FR/LG) background sets. Daytime/twilight/indoor battles unaffected.

### Also Fixes

`DrawOptionMenuTexts` buffer wrap bug — with 17+ Main menu items, text at y≥256 wraps and overwrites the first item. Now only draws visible items (matches scroll redraw behavior).

### Technical

- SaveBlock2 field at end of struct (includes `optionsBattleSpeed` placeholder for merge compatibility with anim speed PR)
- `GetTimeOfDayBlend()` helper function selects between original and brighter blend arrays
- Battle BG brightening hooks into end of `DrawMainBattleBackground`
- Defaults to OFF for existing saves

**Merge note:** Includes `optionsBattleSpeed:1` field declaration in SaveBlock2 (unused on this branch) to avoid bitfield layout conflicts when merged with the double battle speed PR.
