### PR TITLE
fix: pokedex evo page navigation + tile corruption from summary path

### DIFF
--- a/src/palette.c
+++ b/src/palette.c
@@ -435,6 +435,7 @@ void ResetPaletteFadeControl(void)
     gPaletteFade.multipurpose2 = 0; // assign same value twice
     gPaletteFade.yDec = 0;
     gPaletteFade.bufferTransferDisabled = FALSE;
+    gPaletteFade.mode = NORMAL_FADE;
     gPaletteFade.shouldResetBlendRegisters = FALSE;
     gPaletteFade.hardwareFadeFinishing = FALSE;
     gPaletteFade.softwareFadeFinishing = FALSE;

--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -4637,6 +4637,15 @@ static void PrintInfoScreenTextSmall(const u8* str, u8 left, u8 top)
 
     AddTextPrinterParameterized4(0, 0, left, top, 0, 0, color, 0, str);
 }
+static void PrintInfoScreenTextSmallGray(const u8* str, u8 left, u8 top)
+{
+    u8 color[3];
+    color[0] = TEXT_COLOR_TRANSPARENT;
+    color[1] = TEXT_DYNAMIC_COLOR_5;
+    color[2] = TEXT_COLOR_DARK_GRAY;
+
+    AddTextPrinterParameterized4(0, 0, left, top, 0, 0, color, 0, str);
+}
 static void PrintInfoScreenTextSmallWhite(const u8* str, u8 left, u8 top)
 {
     u8 color[3];
@@ -6777,7 +6786,19 @@ static void Task_LoadEvolutionScreen(u8 taskId)
         GetSeenFlagTargetSpecies();
         if (sPokedexView->sEvoScreenData.numAllEvolutions != 0 && sPokedexView->sEvoScreenData.numSeen != 0)
         {
-            sPokedexView->sEvoScreenData.arrowSpriteId = CreateSprite(&sSpriteTemplate_Arrow, 7, 58, 0);
+            // Find first seen entry for initial arrow position
+            u8 initPos = 0;
+            u8 j;
+            for (j = 0; j < sPokedexView->sEvoScreenData.numAllEvolutions; j++)
+            {
+                if (sPokedexView->sEvoScreenData.seen[j] == TRUE)
+                {
+                    initPos = j;
+                    break;
+                }
+            }
+            sPokedexView->sEvoScreenData.menuPos = initPos;
+            sPokedexView->sEvoScreenData.arrowSpriteId = CreateSprite(&sSpriteTemplate_Arrow, 7, 58 + 9 * initPos, 0);
             gSprites[sPokedexView->sEvoScreenData.arrowSpriteId].animNum = 2;
         }
         gMain.state++;
@@ -6838,38 +6859,42 @@ static void Task_HandleEvolutionScreenInput(u8 taskId)
     }
     #endif
 
-    if (sPokedexView->sEvoScreenData.numAllEvolutions != 0 && sPokedexView->sEvoScreenData.numSeen != 0)
+    if (sPokedexView->sEvoScreenData.numAllEvolutions != 0)
     {
         u8 i;
         u8 base_y = 58;
         u8 base_y_offset = 9;
         u8 pos = sPokedexView->sEvoScreenData.menuPos;
         u8 max = sPokedexView->sEvoScreenData.numAllEvolutions;
-        if (JOY_NEW(DPAD_DOWN))
+        if (sPokedexView->sEvoScreenData.numSeen > 1 && JOY_NEW(DPAD_DOWN))
         {
             while (TRUE)
             {
                 pos += 1;
                 if (pos >= max)
                     pos = 0;
-
                 if (sPokedexView->sEvoScreenData.seen[pos] == TRUE)
                     break;
             }
             gSprites[sPokedexView->sEvoScreenData.arrowSpriteId].y = base_y + base_y_offset * pos;
             sPokedexView->sEvoScreenData.menuPos = pos;
         }
-        else if (JOY_NEW(DPAD_UP))
+        else if (sPokedexView->sEvoScreenData.numSeen > 1 && JOY_NEW(DPAD_UP))
         {
-            if (sPokedexView->sEvoScreenData.menuPos == 0)
-                sPokedexView->sEvoScreenData.menuPos = sPokedexView->sEvoScreenData.numAllEvolutions - 1;
-            else
-                sPokedexView->sEvoScreenData.menuPos -= 1;
-
-            gSprites[sPokedexView->sEvoScreenData.arrowSpriteId].y = base_y + base_y_offset * sPokedexView->sEvoScreenData.menuPos;
+            while (TRUE)
+            {
+                if (pos == 0)
+                    pos = max - 1;
+                else
+                    pos -= 1;
+                if (sPokedexView->sEvoScreenData.seen[pos] == TRUE)
+                    break;
+            }
+            gSprites[sPokedexView->sEvoScreenData.arrowSpriteId].y = base_y + base_y_offset * pos;
+            sPokedexView->sEvoScreenData.menuPos = pos;
         }
 
-        if (JOY_NEW(A_BUTTON))
+        if (JOY_NEW(A_BUTTON) && sPokedexView->sEvoScreenData.seen[sPokedexView->sEvoScreenData.menuPos])
         {
             if (sPokedexView->isSearchResults && sPokedexView->originalSearchSelectionNum == 0)
                 sPokedexView->originalSearchSelectionNum = sPokedexListItem->dexNum;
@@ -6941,7 +6966,10 @@ static void HandleTargetSpeciesPrint(u8 taskId, u16 targetSpecies, u16 previousT
     else
         StringCopy(gStringVar3, gText_ThreeQuestionMarks); //show questionmarks instead of name
     StringExpandPlaceholders(gStringVar3, gText_EVO_Name); //evolution mon name
-    PrintInfoScreenTextSmall(gStringVar3, base_x, base_y + base_y_offset*base_i); //evolution mon name
+    if (seen)
+        PrintInfoScreenTextSmall(gStringVar3, base_x, base_y + base_y_offset*base_i); //evolution mon name
+    else
+        PrintInfoScreenTextSmallGray(gStringVar3, base_x, base_y + base_y_offset*base_i); //gray for unseen
 
     //Print mon icon in the top row
     if (isEevee)
@@ -6969,13 +6997,14 @@ static void HandleTargetSpeciesPrint(u8 taskId, u16 targetSpecies, u16 previousT
 static void CreateCaughtBallEvolutionScreen(u16 targetSpecies, u8 x, u8 y, u16 unused)
 {
     bool8 owned = GetSetPokedexFlag(SpeciesToNationalPokedexNum(targetSpecies), FLAG_GET_CAUGHT);
+    bool8 seen = GetSetPokedexFlag(SpeciesToNationalPokedexNum(targetSpecies), FLAG_GET_SEEN);
     if (owned)
         BlitBitmapToWindow(0, sCaughtBall_Gfx, x, y-1, 8, 16);
-    else
+    else if (seen)
     {
-        //FillWindowPixelRect(0, PIXEL_FILL(0), x, y, 8, 16); //not sure why this was even here
         PrintInfoScreenTextSmall(gText_OneDash, x+1, y-1);
     }
+    // Unseen: show nothing (no dash, no ball)
 }
 
 static void HandlePreEvolutionSpeciesPrint(u8 taskId, u16 preSpecies, u16 species, u8 base_x, u8 base_y, u8 base_y_offset, u8 base_i)
@@ -7002,7 +7031,10 @@ static void HandlePreEvolutionSpeciesPrint(u8 taskId, u16 preSpecies, u16 specie
     }
     #endif
 
-    PrintInfoScreenTextSmall(gStringVar3, base_x, base_y + base_y_offset*base_i); //evolution mon name
+    if (seen)
+        PrintInfoScreenTextSmall(gStringVar3, base_x, base_y + base_y_offset*base_i);
+    else
+        PrintInfoScreenTextSmallGray(gStringVar3, base_x, base_y + base_y_offset*base_i);
 
     if (base_i < 3)
     {
@@ -7313,7 +7345,10 @@ static u8 PrintEvolutionTargetSpeciesAndMethod(u8 taskId, u16 species, u8 depth,
             StringExpandPlaceholders(gStringVar4, gText_EVO_UNKNOWN );
             break;
         }//Switch end
-        PrintInfoScreenTextSmall(gStringVar4, base_x + depth_x*depth+base_x_offset, base_y + base_y_offset*base_i); //Print actual instructions
+        if (GetSetPokedexFlag(SpeciesToNationalPokedexNum(targetSpecies), FLAG_GET_SEEN))
+            PrintInfoScreenTextSmall(gStringVar4, base_x + depth_x*depth+base_x_offset, base_y + base_y_offset*base_i); //Print actual instructions
+        else
+            PrintInfoScreenTextSmallGray(gStringVar4, base_x + depth_x*depth+base_x_offset, base_y + base_y_offset*base_i); //Gray for unseen
 
         depth_i += PrintEvolutionTargetSpeciesAndMethod(taskId, targetSpecies, depth+1, base_i+1);
     }//For loop end


### PR DESCRIPTION
Noticed the tile corruption issue from Summary > Pokedex still happening rarely.  this _should_ resolve it.

Bigger fix here is the Pokedex evos screen.  I noticed it was all messed up on Eevees page if you had seen only a couple Eeveelutions, not including the first (Vaporeon) the engine would start the cursor on Vaporeon (and let you see the page which is wrong) and then struggle to get to the entries you DID see, and then break on the way up and let you see more eevelutions that werent seen in the dex.  this both takes care of the arrow placement/navigation bug, and adds a better UX by dimming the unseen pages and removing the '-' to reinforce they arent selectable, its just read-only text for reference.

**Description:**

### Evo Page Navigation Fix

Fixes broken up/down navigation on the Pokedex EVO page:

**Problems fixed:**
- DPAD_UP didn't skip unseen entries (could land on entries with no page to view)
- Arrow sometimes didn't appear (required `numSeen != 0` which failed on fresh saves before battles)
- Arrow started at index 0 regardless of whether that entry was seen
- Could select unseen entries with A_BUTTON

**New behavior:**
- Arrow always shows when evolutions exist AND at least one has been seen
- Arrow starts on the first seen entry
- UP/DOWN skip unseen entries (both directions use `while(TRUE)` wrap loop)
- Only moves when `numSeen > 1` (no movement if only 1 seen)
- A_BUTTON only works on seen entries
- Unseen entries display in gray text (no dash/ball prefix) — clearly "disabled" visually
- Pre-evolution text also grayed when pre-evo is unseen (e.g. "Wartortle evolves from Squirtle")


<img width="372" height="249" alt="image" src="https://github.com/user-attachments/assets/611878ce-9ef6-4092-953a-a67238ee8134" />

### Tile Corruption Fix (palette.c)

**Why the previous fix (8e27909) wasn't sufficient:**

The previous commit in `OpenPokedexInfoScreen` added VRAM clearing (`DmaFillLarge16`) and palette resets. This fixed corruption from leftover sprite/tile data. However, the corruption still occurred specifically **after battles** because:

The battle system uses `BeginTimeOfDayPaletteFade` which sets `gPaletteFade.mode = TIME_OF_DAY_FADE`. When the battle ends and returns to the overworld, this mode persists. When the Pokedex is opened, it calls `ResetPaletteFade()` → `ResetPaletteFadeControl()` — but **`ResetPaletteFadeControl` never reset the `mode` field**. It only reset active, y, targetY, blendColor, etc.

With `mode` stuck at `TIME_OF_DAY_FADE`, the Pokedex's `UpdatePaletteFade()` dispatched to `UpdateTimeOfDayPaletteFade()` instead of `UpdateNormalPaletteFade()`. The TOD fade path applies time-of-day tinting to palettes and uses `bld0`/`bld1` pointers (which are stale/NULL), causing palette corruption that manifests as garbled tiles.

**Fix:** Added `gPaletteFade.mode = NORMAL_FADE;` to `ResetPaletteFadeControl()`. This ensures any screen that resets palette fade state also gets a clean fade mode, regardless of what mode was active before (overworld TOD, fast fade, hardware fade, etc.).

