### PR TITLE
fix: don't clear designated follower when moving mon within party via PC

### DIFF
--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -567,6 +567,8 @@ static u32 sItemIconGfxBuffer[98];
 EWRAM_DATA static u8 sPreviousBoxOption = 0;
 EWRAM_DATA static struct ChooseBoxMenu *sChooseBoxMenu = NULL;
 EWRAM_DATA static struct PokemonStorageSystemData *sStorage = NULL;
+EWRAM_DATA static u32 sSavedFollowerPersonality = 0;
+EWRAM_DATA static u32 sSavedFollowerOtId = 0;
 EWRAM_DATA static bool8 sInPartyMenu = 0;
 EWRAM_DATA static u8 sCurrentBoxOption = 0;
 EWRAM_DATA static u8 sDepositBoxId = 0;
@@ -579,6 +581,7 @@ EWRAM_DATA static s8 sCursorPosition = 0;
 EWRAM_DATA static bool8 sIsMonBeingMoved = 0;
 EWRAM_DATA static u8 sMovingMonOrigBoxId = 0;
 EWRAM_DATA static u8 sMovingMonOrigBoxPos = 0;
+EWRAM_DATA static bool8 sMovingMonWasDesignatedFollower = FALSE;
 EWRAM_DATA static bool8 sAutoActionOn = 0;
 
 // Main tasks
@@ -1700,6 +1703,25 @@ static void CreateMainMenu(u8 whichMenu, s16 *windowIdPtr)
 
 static void CB2_ExitPokeStorage(void)
 {
+    // Reconcile designated follower: find the mon by identity in the current party
+    if (sSavedFollowerPersonality != 0)
+    {
+        u8 i;
+        bool8 found = FALSE;
+        for (i = 0; i < PARTY_SIZE; i++)
+        {
+            if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES) != SPECIES_NONE
+                && GetMonData(&gPlayerParty[i], MON_DATA_PERSONALITY) == sSavedFollowerPersonality
+                && GetMonData(&gPlayerParty[i], MON_DATA_OT_ID) == sSavedFollowerOtId)
+            {
+                gSaveBlock1Ptr->designatedFollower = i + 1;
+                found = TRUE;
+                break;
+            }
+        }
+        if (!found)
+            gSaveBlock1Ptr->designatedFollower = 0; // Mon was deposited/traded
+    }
     sPreviousBoxOption = GetCurrentBoxOption();
     gFieldCallback = FieldTask_ReturnToPcMenu;
     SetMainCallback2(CB2_ReturnToField);
@@ -2009,6 +2031,18 @@ void EnterPokeStorage(u8 boxOption)
 {
     ResetTasks();
     sCurrentBoxOption = boxOption;
+    // Save designated follower identity for reconciliation on exit
+    if (gSaveBlock1Ptr->designatedFollower != 0 && gSaveBlock1Ptr->designatedFollower <= PARTY_SIZE)
+    {
+        u8 slot = gSaveBlock1Ptr->designatedFollower - 1;
+        sSavedFollowerPersonality = GetMonData(&gPlayerParty[slot], MON_DATA_PERSONALITY);
+        sSavedFollowerOtId = GetMonData(&gPlayerParty[slot], MON_DATA_OT_ID);
+    }
+    else
+    {
+        sSavedFollowerPersonality = 0;
+        sSavedFollowerOtId = 0;
+    }
     sStorage = Alloc(sizeof(*sStorage));
     if (sStorage == NULL)
     {
@@ -6441,12 +6475,14 @@ static void SetMovingMonData(u8 boxId, u8 position)
 {
     if (boxId == TOTAL_BOXES_COUNT)
     {
-        if (gSaveBlock1Ptr->designatedFollower == position + 1)
-            gSaveBlock1Ptr->designatedFollower = 0;
+        sMovingMonWasDesignatedFollower = (gSaveBlock1Ptr->designatedFollower == position + 1);
         sStorage->movingMon = gPlayerParty[sCursorPosition];
     }
     else
+    {
+        sMovingMonWasDesignatedFollower = FALSE;
         BoxMonAtToMon(boxId, position, &sStorage->movingMon);
+    }
 
     PurgeMonOrBoxMon(boxId, position);
     sMovingMonOrigBoxId = boxId;
@@ -6538,6 +6574,9 @@ static void SetPlacedMonData(u8 boxId, u8 position)
             SetBoxMonData(&sStorage->movingMon.box, MON_DATA_BOX_AILMENT, &value);
         }
         gPlayerParty[position] = sStorage->movingMon;
+        // If this mon was the designated follower, update to its new party slot
+        if (sMovingMonWasDesignatedFollower)
+            gSaveBlock1Ptr->designatedFollower = position + 1;
     }
     else
     {
@@ -6555,6 +6594,9 @@ static void SetPlacedMonData(u8 boxId, u8 position)
                 BoxMonRestorePP(&sStorage->movingMon.box);
             }
         SetBoxMonAt(boxId, position, &sStorage->movingMon.box);
+        // Clear designated follower if this mon was the designated one being deposited
+        if (sMovingMonWasDesignatedFollower)
+            gSaveBlock1Ptr->designatedFollower = 0;
     }
 }
 
@@ -6578,6 +6620,8 @@ static void SetShiftedMonData(u8 boxId, u8 position)
     SetDisplayMonData(&sStorage->movingMon, MODE_PARTY);
     sMovingMonOrigBoxId = boxId;
     sMovingMonOrigBoxPos = position;
+    // The displaced mon is now the moving mon — it's not the designated follower
+    sMovingMonWasDesignatedFollower = FALSE;
 }
 
 static bool8 TryStorePartyMonInBox(u8 boxId)
@@ -7005,6 +7049,8 @@ s16 CompactPartySlots(void)
         ZeroMonData(&gPlayerParty[last]);
 
     // Update designated follower slot to track compaction (0=none, 1-6=slot+1)
+    // Skip if a mon is currently being moved (it will be placed back)
+    if (!sIsMonBeingMoved)
     {
         u8 df = gSaveBlock1Ptr->designatedFollower;
         if (df != 0 && df <= PARTY_SIZE)


### PR DESCRIPTION
an edge case i noticed that we simply didn't guard against with the desigated follower commit. handled it here.
it actually works well, even if the pokemon does enter the box in the session, if its back in your party, it's still following you.  lets you re-organize your party and stuff and not have the follower reset.

**Description:**

Fixes a bug where the designated follower would reset when repositioning the Pokemon within the party using the PC's "Move" feature, even though the mon never entered a box.

**Root cause:** The original implementation cleared `designatedFollower` in `SetMovingMonData` when a party mon was picked up. Multi-swap operations, `CompactPartySlots`, and the complex pickup/place/shift cycle made it impossible to reliably track the slot index through intermediate states.

**Fix:** Identity-based reconciliation on PC exit.

- On PC entry (`EnterPokeStorage`): save the designated mon's `personality` and `OT ID`
- On PC exit (`CB2_ExitPokeStorage`): scan the party for that identity
  - Found → update `designatedFollower` to the mon's current slot
  - Not found → clear `designatedFollower` (mon was deposited to a box)

This handles all cases regardless of how many swaps/moves happen during the session. Personality + OT ID is a unique identifier for any legitimately obtained Pokemon (32-bit random value + trainer ID).

**Does not affect:**
- Normal deposit/release/trade clearing (still works via existing guards)
- Battle Frontier designation behavior (separate code path)
- `CompactPartySlots` remap logic (still runs for non-PC cases like party menu)
