### PR TITLE
fix: show message when no party mon can Surf

### DIFF
--- a/data/scripts/surf.inc
+++ b/data/scripts/surf.inc
@@ -1,6 +1,6 @@
 EventScript_UseSurf::
 	checkpartymove MOVE_SURF
-	goto_if_eq VAR_RESULT, PARTY_SIZE, EventScript_EndUseSurf
+	goto_if_eq VAR_RESULT, PARTY_SIZE, EventScript_CantUseSurf
 	bufferpartymonnick STR_VAR_1, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT
 	lockall
@@ -11,4 +11,10 @@ EventScript_UseSurf::
 EventScript_ReleaseUseSurf::
 	releaseall
 EventScript_EndUseSurf::
+	end
+
+EventScript_CantUseSurf::
+	lockall
+	msgbox gText_CantUseSurf, MSGBOX_DEFAULT
+	releaseall
 	end

--- a/data/text/surf.inc
+++ b/data/text/surf.inc
@@ -4,3 +4,6 @@ gText_WantToUseSurf::
 
 gText_PlayerUsedSurf::
 	.string "{STR_VAR_1} used Surf!$"
+
+gText_CantUseSurf::
+	.string "None of your Pokémon can Surf.$"


### PR DESCRIPTION
**Description:**

**Before:** After obtaining Surf (Badge 5 / HM03), pressing A on water triggers `EventScript_UseSurf`. If no party mon knows Surf, the script's `checkpartymove` fails and jumps to `end` — producing only a beep with no visible feedback. The player has no indication why surfing didn't work.

**After:** Shows "None of your Pokémon can Surf." in a message box when pressing A on water with no valid surfer in the party.

**Changes:**
- `data/scripts/surf.inc`: Added `EventScript_CantUseSurf` label with `lockall` + `msgbox` + `releaseall`
- `data/text/surf.inc`: Added `gText_CantUseSurf` string

**Does not affect:**
- Normal surfing (party has Surf-knowing mon → works as before)
- Pre-badge/HM behavior (A on water still does nothing)
- Waterfall interaction (has its own script/message)