### PR TITLE
[READ FIRST] cleanup: remove chain fishing remnants

### DIFF
--- a/data/maps/DewfordTown/scripts.inc
+++ b/data/maps/DewfordTown/scripts.inc
@@ -723,15 +723,7 @@ DewfordTown_Text_ThrowInFishingAdvice:
 	.string "Sometimes you can snag something\n"
 	.string "immediately, but with bigger catches,\l"
 	.string "you need to time the pulls on your Rod\l"
-	.string "to haul them in.\p"
-	.string "Also, if you chain your fishing strikes\n"
-	.string "you may encounter different colored\l"
-	.string "Pokémon.\p"
-	.string "Fishing strikes means defeating the\n"
-	.string "wild Pokémon and starting a new\l"
-	.string "fishing encounter.\p"
-	.string "If you run away or whiteout, you\n"
-	.string "will lose your fishing strike!$"
+	.string "to haul them in.$"
 
 DewfordTown_Text_ThatsTooBadThen:
 	.string "Oh, is that so?\n"
@@ -755,15 +747,7 @@ DewfordTown_Text_FishingAdvice:
 	.string "Sometimes you can snag something\n"
 	.string "immediately, but with bigger catches,\l"
 	.string "you need to time the pulls on your Rod\l"
-	.string "to haul them in.\p"
-	.string "Also, if you chain your fishing strikes\n"
-	.string "you may encounter different colored\l"
-	.string "Pokémon.\p"
-	.string "Fishing strikes means defeating the\n"
-	.string "wild Pokémon and starting a new\l"
-	.string "fishing encounter.\p"
-	.string "If you run away or whiteout, you\n"
-	.string "will lose your fishing strike!$"
+	.string "to haul them in.$"
 
 DewfordTown_Text_XIsTheBiggestHappeningThingRight:
 	.string "I like what's hip, happening, and trendy.\n"

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5053,9 +5053,6 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
     }
     else // Player is the OT
     {
-        u32 rolls = 0;
-        u32 shinyRolls = 0;
-
         value = gSaveBlock2Ptr->playerTrainerId[0]
               | (gSaveBlock2Ptr->playerTrainerId[1] << 8)
               | (gSaveBlock2Ptr->playerTrainerId[2] << 16)


### PR DESCRIPTION
I did this before I successfully rebuilt Chain fishing in this PR https://github.com/resetes12/pokeemerald/pull/152
If we want to merge that back in, ignore this and reject it - this is just if you want to truly strip out chaining for increase shiny chance, this just cleans the code up for that.

---

Discovered this as I stumbled on that NPC and wanted to know what the shiny rate increase was.. but discovered it was removed.  (do you want to try and implement it?  i think i have a fairly simple fix that would let it work with Synchronize by preserving low half personality bits that encode nature)

in any case, this cleans it up!

--

Chain fishing was removed in 2d8da192e but leftover NPC text and dead code variables remained.

- Remove chain fishing advice from Dewford fisherman NPC (both text blocks)
- Remove unused rolls/shinyRolls variables in CreateBoxMon

