### PR TITLE
feat: re-implement chain fishing with Synchronize-safe shiny rerolls

### DIFF
--- a/include/wild_encounter.h
+++ b/include/wild_encounter.h
@@ -33,6 +33,8 @@ bool8 StandardWildEncounter(u16 currMetaTileBehavior, u16 previousMetaTileBehavi
 bool8 SweetScentWildEncounter(void);
 bool8 DoesCurrentMapHaveFishingMons(void);
 void FishingWildEncounter(u8 rod);
+extern u8 gChainFishingStreak;
+extern bool8 gIsFishingEncounter;
 u16 GetLocalWildMon(bool8 *isWaterMon);
 u16 GetLocalWaterMon(void);
 bool8 UpdateRepelCounter(void);

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -6089,6 +6089,10 @@ static void FreeResetData_ReturnToOvOrDoEvolutions(void)
 {
     if (!gPaletteFade.active)
     {
+        // Reset fishing chain: preserve only on fishing encounter win/catch
+        if (!gIsFishingEncounter || (gBattleOutcome != B_OUTCOME_WON && gBattleOutcome != B_OUTCOME_CAUGHT))
+            gChainFishingStreak = 0;
+        gIsFishingEncounter = FALSE;
         ResetSpriteData();
         if (gLeveledUpInBattle == 0 || (gBattleOutcome != B_OUTCOME_WON && gBattleOutcome != B_OUTCOME_CAUGHT))
         {

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -2153,6 +2153,7 @@ static bool8 Fishing_NotEvenNibble(struct Task *task)
 
 static bool8 Fishing_GotAway(struct Task *task)
 {
+    gChainFishingStreak = 0;
     AlignFishingAnimationFrames();
     StartSpriteAnim(&gSprites[gPlayerAvatar.spriteId], GetFishingNoCatchDirectionAnimNum(GetPlayerFacingDirection()));
     FillWindowPixelBuffer(0, PIXEL_FILL(1));

--- a/src/fieldmap.c
+++ b/src/fieldmap.c
@@ -71,6 +71,7 @@ const struct MapHeader *const GetMapHeaderFromConnection(const struct MapConnect
 
 void InitMap(void)
 {
+    gChainFishingStreak = 0;
     InitMapLayoutData(&gMapHeader);
     SetOccupiedSecretBaseEntranceMetatiles(gMapHeader.events);
     RunOnLoadMapScript();

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5053,9 +5053,6 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
     }
     else // Player is the OT
     {
-        u32 rolls = 0;
-        u32 shinyRolls = 0;
-
         value = gSaveBlock2Ptr->playerTrainerId[0]
               | (gSaveBlock2Ptr->playerTrainerId[1] << 8)
               | (gSaveBlock2Ptr->playerTrainerId[2] << 16)

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -26,8 +26,13 @@
 extern const u8 EventScript_RepelWoreOff[];
 
 #define MAX_ENCOUNTER_RATE 2880
+#define MAX_CHAIN_FISHING_STREAK 255
 
 #define NUM_FEEBAS_SPOTS 6
+
+EWRAM_DATA u8 gChainFishingStreak = 0;
+EWRAM_DATA static u16 sLastFishingSpecies = 0;
+EWRAM_DATA bool8 gIsFishingEncounter = FALSE;
 
 // Number of accessible fishing spots in each section of Route 119
 // Each section is an area of the route between the y coordinates in sRoute119WaterTileData
@@ -843,6 +848,8 @@ void FishingWildEncounter(u8 rod)
 {
     u16 species;
 
+    gIsFishingEncounter = TRUE;
+
     if (CheckFeebas() == TRUE)
     {
         u8 level = ChooseWildMonLevel(&sWildFeebas);
@@ -854,6 +861,59 @@ void FishingWildEncounter(u8 rod)
     {
         species = GenerateFishingWildMon(gWildMonHeaders[GetCurrentMapWildMonHeaderId()].fishingMonsInfo, rod);
     }
+
+    // Chain fishing shiny reroll (applied to already-created enemy mon)
+    if (gChainFishingStreak > 0)
+    {
+        u32 otId = GetMonData(&gEnemyParty[0], MON_DATA_OT_ID);
+        u32 personality = GetMonData(&gEnemyParty[0], MON_DATA_PERSONALITY);
+        u32 shinyValue = GET_SHINY_VALUE(otId, personality);
+        u32 shinyThreshold = SHINY_ODDS;
+        u8 pokemon_nature = GetNatureFromPersonality(personality);
+
+        if (gSaveBlock1Ptr->tx_Features_ShinyChance == 1)
+            shinyThreshold = 16;
+        else if (gSaveBlock1Ptr->tx_Features_ShinyChance == 2)
+            shinyThreshold = 32;
+        else if (gSaveBlock1Ptr->tx_Features_ShinyChance == 3)
+            shinyThreshold = 64;
+        else if (gSaveBlock1Ptr->tx_Features_ShinyChance == 4)
+            shinyThreshold = 128;
+
+        if (shinyValue >= shinyThreshold) // not already shiny
+        {
+            u32 rolls = 0;
+            u32 shinyRolls = 1 + 2 * gChainFishingStreak;
+            do {
+                personality = Random32();
+                shinyValue = GET_SHINY_VALUE(otId, personality);
+                rolls++;
+            } while (shinyValue >= shinyThreshold && rolls < shinyRolls);
+
+            // If shiny found, fix nature and apply
+            if (shinyValue < shinyThreshold)
+            {
+                // Use FORCE_SHINY technique to match nature
+                while (GetNatureFromPersonality(personality) != pokemon_nature)
+                {
+                    personality = Random32();
+                    personality = ((((Random() % shinyThreshold) ^ (HIHALF(otId) ^ LOHALF(otId))) ^ LOHALF(personality)) << 16) | LOHALF(personality);
+                }
+                // Must re-create the mon with new personality to avoid Bad Egg (checksum)
+                {
+                    u16 monSpecies = GetMonData(&gEnemyParty[0], MON_DATA_SPECIES);
+                    u8 monLevel = GetMonData(&gEnemyParty[0], MON_DATA_LEVEL);
+                    ZeroEnemyPartyMons();
+                    CreateMon(&gEnemyParty[0], monSpecies, monLevel, USE_RANDOM_IVS, TRUE, personality, OT_ID_PLAYER_ID, 0);
+                }
+            }
+        }
+    }
+
+    // Update chain: increment on every successful fishing encounter
+    if (gChainFishingStreak < MAX_CHAIN_FISHING_STREAK)
+        gChainFishingStreak++;
+
     IncrementGameStat(GAME_STAT_FISHING_ENCOUNTERS);
     SetPokemonAnglerSpecies(species);
     BattleSetup_StartWildBattle();


### PR DESCRIPTION

<p><strong>Description:</strong></p>
<p>Re-adds chain fishing (removed in 2d8da192e due to Synchronize conflicts). Consecutive successful fishing encounters increase shiny chance via extra personality rerolls.</p>
<h3>How it works</h3>
<p>Each successful fishing encounter increments the chain (max 255). The shiny reroll formula: <code>1 + 2 × streak</code> total rolls of a random personality, each checked against the player's shiny threshold. If a shiny roll succeeds, the personality is reconstructed to preserve the nature set by Synchronize (using the same technique as <code>FLAG_FORCE_SHINY</code>).</p>
<h3>Synchronize compatibility</h3>
<p>The original implementation overwrote nature during shiny rerolls, breaking Synchronize. This version:</p>
<ol>
<li>Performs raw shiny rerolls (random personality checked against threshold)</li>
<li>If shiny found, reconstructs a personality that is BOTH shiny AND matches the original nature</li>
<li>Re-creates the mon from scratch with <code>CreateMon</code> to maintain valid checksum/encryption</li>
<li>Works identically with both Synchronize settings (50% vanilla, 100% guaranteed)</li>
</ol>
<h3>Chain breaks on</h3>
<ul>
<li>"It got away" (too slow pressing A)</li>
<li>Map change (fly/walk/teleport)</li>
<li>Running from or losing a fishing battle</li>
<li>Any non-fishing wild encounter</li>
</ul>
<h3>Chain does NOT break on</h3>
<ul>
<li>"Not even a nibble" (no bite) — encourages patience over save-scumming</li>
<li>Winning/catching the fishing encounter</li>
<li>Opening menus</li>
<li>Different species (Gen 3 has multiple species per fishing spot)</li>
</ul>
<h3>Shiny probability per encounter (formula: <code>1 - (1 - threshold/65536)^rolls</code>)</h3>

Chain | Rolls | 1/8192 (t=8) | 1/4096 (t=16) | 1/2048 (t=32) | 1/1024 (t=64) | 1/512 (t=128)
-- | -- | -- | -- | -- | -- | --
0 | 1 | 0.01% | 0.02% | 0.05% | 0.10% | 0.20%
5 | 11 | 0.13% | 0.27% | 0.54% | 1.07% | 2.13%
10 | 21 | 0.26% | 0.51% | 1.02% | 2.04% | 4.04%
20 | 41 | 0.50% | 1.00% | 1.99% | 3.94% | 7.73%
50 | 101 | 1.23% | 2.45% | 4.84% | 9.43% | 17.8%
100 | 201 | 2.43% | 4.80% | 9.36% | 17.7% | 32.1%



<p>Suction Cups/Sticky Hold in slot 1 provides ~85% bite rate (vs 50% without). A fainted Suction Cups mon works (no HP check). However, Suction Cups and Synchronize both check slot 1 only — players must choose between reliable bites OR nature control.</p>
<h3>Note on NPC text</h3>
<p>The Dewford fisherman's chain fishing advice text is already in the game (was left from the original implementation). If the "remove chain fishing remnants" PR was merged first, this PR should re-add that text or supersede it.</p>
<p><strong>Files:</strong> 6 changed, +68 / -3</p>
</body></html>