### PR TITLE
Fix pokedex shiny toggle for non-default shiny odds

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -4072,7 +4072,7 @@ static void Task_HandleInfoScreenInput(u8 taskId)
             sPokedexView->isShowingShiny = !sPokedexView->isShowingShiny;
 
             if (sPokedexView->isShowingShiny)
-                palData = GetMonSpritePalFromSpeciesAndPersonality(species, 0, 0); // otId=0, personality=0 forces shiny
+                palData = GetMonSpritePalFromSpeciesAndPersonality(species, 0, 0x00010001); // otId=0, personality with shinyValue=0 and non-zero to pass shiny check
             else
                 palData = gMonPaletteTable[species].data;
 


### PR DESCRIPTION
**Description:**

## Bug

The shiny toggle (A button) on the HGSS Pokédex info screen doesn't swap the sprite palette when `tx_Features_ShinyChance` is set to anything other than 0 (1/8192). The button responds and the label updates, but the sprite stays non-shiny.

## Cause

`GetMonSpritePalFromSpeciesAndPersonality` has `&& personality != 0` guards on shiny chance branches 1–4. The Pokédex was calling it with `(species, 0, 0)` to force a shiny palette lookup — this worked for the default branch (no personality guard) but failed on all others.

## Fix

Pass `personality = 0x00010001` instead of `0`. This still produces `GET_SHINY_VALUE(0, 0x00010001) = 0` (passes the shiny threshold) while satisfying the `personality != 0` guard.

## Files changed
- `src/pokedex_plus_hgss.c` — One-line change in `Task_HandleInfoScreenInput`