### PR TITLE
Fix 2x battle speed disabled after capturing a Pokemon

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -924,6 +924,7 @@ static void CB2_InitBattleInternal(void)
     gReservedSpritePaletteCount = MAX_BATTLERS_COUNT;
     SetVBlankCallback(VBlankCB_Battle);
     SetUpBattleVarsAndBirchZigzagoon();
+    gBattleCaptureSuccessActive = FALSE;
 
     if (gBattleTypeFlags & BATTLE_TYPE_MULTI && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
         SetMainCallback2(CB2_HandleStartMultiPartnerBattle);


### PR DESCRIPTION
**Description:**

## Bug

After catching any Pokémon, the 2x Animation Speed option stops working for all subsequent battles. The battle transition still plays at 2x, and the option shows as enabled in the menu, but in-battle animations run at 1x. Persists until ROM reset.

## Cause

`gBattleCaptureSuccessActive` is set to TRUE during the capture celebration (ball shake + jingle) to disable the double-tick so the animation plays correctly. The normal battle exit path (`FreeResetData_ReturnToOvOrDoEvolutions` → `ReturnFromBattleToOverworld`) never clears it. The flag stays TRUE in EWRAM permanently.

`BattleMainCB2` checks `!gBattleCaptureSuccessActive` before running the double-tick, so all future battles skip it.

## Fix

Clear `gBattleCaptureSuccessActive = FALSE` in `CB2_InitBattleInternal` so every battle starts with a clean state.

## Files changed
- `src/battle_main.c` — One line added in `CB2_InitBattleInternal`