### PR TITLE
Fix dynamic surf sprite reverting to generic on party swap

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -3284,6 +3284,15 @@ static void SwitchPartyMon(void)
         gSaveBlock1Ptr->designatedFollower = gPartyMenu.slotId2 + 1;
     else if (gSaveBlock1Ptr->designatedFollower == gPartyMenu.slotId2 + 1)
         gSaveBlock1Ptr->designatedFollower = gPartyMenu.slotId + 1;
+
+    // Track surf mon slot through party swaps
+    {
+        u16 surfSlot = VarGet(VAR_SURF_MON_SLOT);
+        if (surfSlot == gPartyMenu.slotId)
+            VarSet(VAR_SURF_MON_SLOT, gPartyMenu.slotId2);
+        else if (surfSlot == gPartyMenu.slotId2)
+            VarSet(VAR_SURF_MON_SLOT, gPartyMenu.slotId);
+    }
 }
 
 // Finish switching mons or using Softboiled


### PR DESCRIPTION

**Description:**

## Bug

When using the "Dynamic" surf sprites option and swapping party members while surfing, the surf sprite reverts to the generic blob. Persists until a screen transition (battle, building entry, etc.) reloads it.

## Cause

`VAR_SURF_MON_SLOT` stores the party slot index of the surfing Pokémon. Swapping party members moves the mon to a different slot, but the variable isn't updated. `GetSurfMonSpecies()` then reads the wrong species from the new occupant of that slot, `GetSurfablePokemonSprite()` can't find it in the surfable list, and falls back to the generic surf blob.

## Fix

Track `VAR_SURF_MON_SLOT` through party swaps in `SwitchPartyMon()`, same pattern already used for `designatedFollower`.

## Files changed
- `src/party_menu.c` — Update `VAR_SURF_MON_SLOT` when the surfing mon's slot changes