### PR TITLE
Fix slide-in anim playing for non-follower Pokemon

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2704,7 +2704,7 @@ static bool8 ShouldDoSlideInAnim(void) {
         BATTLE_TYPE_INGAME_PARTNER | BATTLE_TYPE_RECORDED | BATTLE_TYPE_TRAINER_HILL)
     )
         return FALSE;
-    if (GetFirstLiveMon() != &gPlayerParty[gBattlerPartyIndexes[gActiveBattler]])
+    if (GetDesignatedFollowerMon() != &gPlayerParty[gBattlerPartyIndexes[gActiveBattler]])
         return FALSE;
     return TRUE;
 }


### PR DESCRIPTION
**Description:**

## Bug

When a designated follower is set to a mon other than party slot 1, the battle slide-in animation (mon walks in from behind trainer) incorrectly plays for the first party mon instead of only playing when the actual visible follower enters battle. The pokeball throw animation should play for any mon that isn't the follower.

## Cause

`ShouldDoSlideInAnim()` used `GetFirstLiveMon()` which always returns the first alive mon in party order (slot 0). It should use `GetDesignatedFollowerMon()` which checks the designated follower slot first, matching what's actually visible on the overworld.

## Fix

Replace `GetFirstLiveMon()` with `GetDesignatedFollowerMon()` in `ShouldDoSlideInAnim()`.

## Files changed
- `src/battle_controller_player.c` — One-line change in `ShouldDoSlideInAnim()`