### PR TITLE
Fix Brighter Nights battle BG tint lost after pokeball open

### DIFF
--- a/src/battle_bg.c
+++ b/src/battle_bg.c
@@ -1274,7 +1274,13 @@ void DrawMainBattleBackground(void)
         && ((gLocalTime.hours >= 0 && gLocalTime.hours < 6) || (gLocalTime.hours >= 21 && gLocalTime.hours < 24)))
     {
         // Blend BG palettes 2-4 (terrain) toward a warm dark tone to lift blacks without hazing
+        // Apply to both buffers so NORMAL_FADE (pokeball open, move anims) restores correctly
         BlendPalettes(0x1C, 3, RGB(10, 10, 14));
+        {
+            u16 i;
+            for (i = BG_PLTT_ID(2); i < BG_PLTT_ID(5); i++)
+                gPlttBufferUnfaded[i] = gPlttBufferFaded[i];
+        }
     }
 }
 


### PR DESCRIPTION
**Description:**

## Bug

With Brighter Nights enabled at night, the subtle stripe pattern in the battle background loses contrast/vanishes after the pokeball opens to send out your Pokémon. The background becomes slightly darker and flatter for the rest of the battle.

## Cause

The Brighter Nights blend (`BlendPalettes(0x1C, 3, RGB(10, 10, 14))`) only wrote to `gPlttBufferFaded`. The pokeball send-out runs `BeginNormalPaletteFade` on BG palettes 1-3, which restores them from `gPlttBufferUnfaded` (untinted). The tint is permanently lost since nothing reapplies it during battle.

## Fix

After applying the blend, copy the tinted result back into `gPlttBufferUnfaded` for palettes 2-4. This way all subsequent `NORMAL_FADE` operations (pokeball open, move animation flashes) restore to the correctly tinted state.

## Files changed
- `src/battle_bg.c` — Copy blended palettes into unfaded buffer in `DrawMainBattleBackground`