### PR TITLE
Fix SaveBlock2 size change breaking existing saves

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -574,6 +574,7 @@ struct SaveBlock2
               u16 optionsCursorMemory:1;
               u16 optionsBattleSpeed:1; // 0 = normal, 1 = double speed animations/bars
               u16 optionsBrighterNights:1; // 0 = normal darkness, 1 = brighter nights
+              u8 padding_savecompat[4]; // Preserve struct size for save compatibility
               u8 shinySeen[NUM_DEX_FLAG_BYTES]; // Tracks whether trainer has ever seen/caught a shiny of each species. Stays the last one in case of
                                                 // overflow.
 }; // sizeof=0xF2C + NUM_DEX_FLAG_BYTES


### PR DESCRIPTION
**Description:**

## Bug

The `global.h` reorder in 14475fae moved `shinySeen` after the option bitfields. This changed `sizeof(SaveBlock2)` by 4 bytes due to alignment/padding differences between bitfields and the byte array. Any save made with the previous struct layout fails checksum validation and is erased on load ("The save file has been erased due to corruption or damage").

## Fix

Add 4 bytes of explicit padding before `shinySeen` to restore the original struct size. Save sector boundaries and checksums now match the previous layout, and existing saves load correctly.

## Files changed
- `include/global.h` — Added `u8 padding_savecompat[4]` between option bitfields and `shinySeen`