### PR TITLE
Fix money loss on whiteout in Battle Frontier wild encounters

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -2961,11 +2961,18 @@ BattleScript_LocalBattleLost::
 	jumpifbattletype BATTLE_TYPE_EREADER_TRAINER, BattleScript_LocalBattleLostEnd
 	jumpifhalfword CMP_EQUAL, gTrainerBattleOpponent_A, TRAINER_SECRET_BASE, BattleScript_LocalBattleLostEnd
 BattleScript_LocalBattleLostPrintWhiteOut::
+	jumpifbattletype BATTLE_TYPE_FRONTIER, BattleScript_LocalBattleLostFrontierWhiteOut
 	jumpifbattletype BATTLE_TYPE_TRAINER, BattleScript_LocalBattleLostEnd
 	printstring STRINGID_PLAYERWHITEOUT
 	waitmessage B_WAIT_TIME_LONG
 	getmoneyreward
 	printstring STRINGID_PLAYERWHITEOUT2
+	waitmessage B_WAIT_TIME_LONG
+	end2
+BattleScript_LocalBattleLostFrontierWhiteOut::
+	printstring STRINGID_PLAYERWHITEOUT
+	waitmessage B_WAIT_TIME_LONG
+	printstring STRINGID_PLAYERWHITEOUT_NOMONEY
 	waitmessage B_WAIT_TIME_LONG
 	end2
 BattleScript_LocalBattleLostEnd::

--- a/include/constants/battle_string_ids.h
+++ b/include/constants/battle_string_ids.h
@@ -389,9 +389,10 @@
 #define STRINGID_PKMNDROPPEDITEM            388
 #define STRINGID_BAGISFULL                  389
 #define STRINGID_FOURITEMSUSED              390
+#define STRINGID_PLAYERWHITEOUT_NOMONEY     391
 
 
-#define BATTLESTRINGS_COUNT                 391
+#define BATTLESTRINGS_COUNT                 392
 
 // This is the string id that gBattleStringsTable starts with.
 // String ids before this (e.g. STRINGID_INTROMSG) are not in the table,

--- a/src/battle_message.c
+++ b/src/battle_message.c
@@ -79,6 +79,7 @@ static const u8 sText_PlayerLostAgainstEnemyTrainer[] = _("{B_PLAYER_NAME} is ou
 static const u8 sText_PlayerPaidPrizeMoney[] = _("{B_PLAYER_NAME} paid ¥{B_BUFF1} as the prize\nmoney…\p… … … …\p{B_PLAYER_NAME} whited out!{PAUSE_UNTIL_PRESS}");
 static const u8 sText_PlayerWhiteout[] = _("{B_PLAYER_NAME} is out of\nusable Pokémon!\p");
 static const u8 sText_PlayerWhiteout2[] = _("{B_PLAYER_NAME} panicked and lost ¥{B_BUFF1}…\p… … … …\p{B_PLAYER_NAME} whited out!{PAUSE_UNTIL_PRESS}");
+static const u8 sText_PlayerWhiteoutNoMoney[] = _("… … … …\p{B_PLAYER_NAME} whited out!{PAUSE_UNTIL_PRESS}");
 static const u8 sText_PreventsEscape[] = _("{B_SCR_ACTIVE_NAME_WITH_PREFIX} prevents\nescape with {B_SCR_ACTIVE_ABILITY}!\p");
 static const u8 sText_CantEscape2[] = _("Can't escape!\p");
 static const u8 sText_AttackerCantEscape[] = _("{B_ATK_NAME_WITH_PREFIX} can't escape!");
@@ -903,6 +904,7 @@ const u8 * const gBattleStringsTable[BATTLESTRINGS_COUNT - BATTLESTRINGS_TABLE_S
     [STRINGID_BAGISFULL - BATTLESTRINGS_TABLE_START] = sText_BagIsFull,
     [STRINGID_PKMNDROPPEDITEM - BATTLESTRINGS_TABLE_START] = sText_PkmnDroppedItem,
     [STRINGID_FOURITEMSUSED - BATTLESTRINGS_TABLE_START] = sText_FourItemsUsed,
+    [STRINGID_PLAYERWHITEOUT_NOMONEY - BATTLESTRINGS_TABLE_START] = sText_PlayerWhiteoutNoMoney,
 };
 
 const u16 gMissStringIds[] =


### PR DESCRIPTION
## Bug

Losing to a wild Pokemon in the Battle Pyramid deducts money and shows the "panicked and lost ¥X" text. Vanilla Emerald shows "out of usable Pokemon" + "whited out" with no money penalty in frontier facilities.

## Cause

`BattleScript_LocalBattleLostPrintTrainersWinText` falls through to the normal whiteout path when `BATTLE_TYPE_TRAINER` is not set. Battle Pyramid wild encounters have `BATTLE_TYPE_FRONTIER` but not `BATTLE_TYPE_TRAINER`, so they hit the money deduction code.

## Fix

- Add a `BATTLE_TYPE_FRONTIER` check in `BattleScript_LocalBattleLostPrintWhiteOut` that routes to a new frontier-specific whiteout path
- Add `STRINGID_PLAYERWHITEOUT_NOMONEY` — displays "whited out" without the money loss text
- The frontier path shows both messages (matching vanilla) but never calls `getmoneyreward`

## Files changed
- `data/battle_scripts_1.s` — Added frontier guard and new `BattleScript_LocalBattleLostFrontierWhiteOut` label
- `src/battle_message.c` — Added `sText_PlayerWhiteoutNoMoney` string and table entry
- `include/constants/battle_string_ids.h` — Added `STRINGID_PLAYERWHITEOUT_NOMONEY`