### PR TITLE
Fix Battle Frontier Normal/Hard mode pool inversion and Factory display level

### DIFF
--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -346,8 +346,8 @@ static void GenerateOpponentMons(void)
         if (j != (int)ARRAY_COUNT(gSaveBlock2Ptr->frontier.rentalMons))
             continue;
 
-        // "High tier" pokemon are only allowed on open level mode
-        if (lvlMode == FRONTIER_LVL_OPEN && monId > FRONTIER_MONS_HIGH_TIER)
+        // "High tier" pokemon are only allowed on hard (open) level mode
+        if (lvlMode == FRONTIER_LVL_50 && monId > FRONTIER_MONS_HIGH_TIER)
             continue;
 
         // Ensure this species hasn't already been chosen for the opponent
@@ -431,10 +431,7 @@ static void SetPlayerAndOpponentParties(void)
             gFacilityTrainerMons = gBattleFrontierMons;
         else if (gSaveBlock2Ptr->optionStyle == 0) //on
             gFacilityTrainerMons = gBattleFrontierMonsSplit;
-        if (gSaveBlock2Ptr->frontier.lvlMode != FRONTIER_LVL_50)
-            monLevel = FRONTIER_MAX_LEVEL_OPEN;
-        else
-            monLevel = FRONTIER_MAX_LEVEL_50;
+        monLevel = GetFrontierEnemyMonLevel(gSaveBlock2Ptr->frontier.lvlMode);
     }
 
     if (gSpecialVar_0x8005 < 2)
@@ -807,7 +804,7 @@ void FillFactoryBrainParty(void)
 
         if (gFacilityTrainerMons[monId].species == SPECIES_UNOWN)
             continue;
-        if (lvlMode == FRONTIER_LVL_OPEN && monId > FRONTIER_MONS_HIGH_TIER)
+        if (lvlMode == FRONTIER_LVL_50 && monId > FRONTIER_MONS_HIGH_TIER)
             continue;
 
         for (j = 0; j < (int)ARRAY_COUNT(gSaveBlock2Ptr->frontier.rentalMons); j++)

--- a/src/battle_factory_screen.c
+++ b/src/battle_factory_screen.c
@@ -1749,10 +1749,7 @@ static void CreateFrontierFactorySelectableMons(u8 firstMonId)
         gFacilityTrainerMons = gBattleFrontierMons;
     else if (gSaveBlock2Ptr->optionStyle == 0) //on
         gFacilityTrainerMons = gBattleFrontierMonsSplit;
-    if (gSaveBlock2Ptr->frontier.lvlMode != FRONTIER_LVL_50)
-        level = 50;
-    else
-        level = FRONTIER_MAX_LEVEL_50;
+    level = GetFrontierEnemyMonLevel(gSaveBlock2Ptr->frontier.lvlMode);
 
     rentalRank = GetNumPastRentalsRank(battleMode, lvlMode);
     otId = T1_READ_32(gSaveBlock2Ptr->playerTrainerId);

--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -1823,9 +1823,8 @@ static void FillTrainerParty(u16 trainerId, u8 firstMonId, u8 monCount)
     {
         u16 monId = monSet[Random() % bfMonCount];
 
-        // "High tier" Pokémon are only allowed on open level mode
-        // 20 is not a possible value for level here
-        if (lvlMode == FRONTIER_LVL_OPEN && monId > FRONTIER_MONS_HIGH_TIER)
+        // "High tier" Pokémon are only allowed on hard (open) level mode
+        if (lvlMode == FRONTIER_LVL_50 && monId > FRONTIER_MONS_HIGH_TIER)
             continue;
 
         // Ensure this Pokémon species isn't a duplicate.
@@ -1946,7 +1945,7 @@ u16 GetRandomFrontierMonFromSet(u16 trainerId)
         // "High tier" Pokémon are only allowed on open level mode
         // 20 is not a possible value for level here
         monId = monSet[Random() % numMons];
-    } while(lvlMode == FRONTIER_LVL_OPEN && monId > FRONTIER_MONS_HIGH_TIER);
+    } while(lvlMode == FRONTIER_LVL_50 && monId > FRONTIER_MONS_HIGH_TIER);
 
     return monId;
 }


### PR DESCRIPTION
this is a pretty big bug + fix, take a look before merging.   I was wondering why Normal frontier always felt tough - here is why lol.


## Bug

Two issues with the Battle Frontier's Normal/Hard mode selection:

1. **Mon pool is inverted**: High-tier mons (Dragonite, Tyranitar, legendary birds/beasts, Gen 4 evolutions) are excluded from Hard mode and allowed in Normal mode. This is the opposite of intended behavior — Hard should feature the stronger pool.

2. **Factory display level is wrong**: The rental mon selection/swap summary screen shows mons at level 100 in Normal mode and level 50 in Hard mode. Both modes fight at level 50, so the summary should always show level 50 stats.

## Cause

When vanilla's "Lv50" / "Open Level" modes were renamed to "Normal" / "Hard", the code logic wasn't flipped to match:

- The `FRONTIER_MONS_HIGH_TIER` exclusion check still references `FRONTIER_LVL_OPEN` (now Hard), excluding strong mons from Hard instead of Normal.
- The Factory screen's level assignment has an inverted condition, and `GenerateInitialRentalMons` uses `FRONTIER_MAX_LEVEL_50` (set to 100) instead of the actual battle level.

## Fix

- Flip the `FRONTIER_MONS_HIGH_TIER` checks in `battle_tower.c` and `battle_factory.c` from `FRONTIER_LVL_OPEN` to `FRONTIER_LVL_50`, so Normal mode excludes high-tier mons and Hard mode includes them.
- Replace the Factory's hardcoded level constants with `GetFrontierEnemyMonLevel()` in both the selection screen and initial rental generation, ensuring the display always matches the actual battle level.

## Scope

- Battle Tower trainer generation (all facilities sharing that path)
- Battle Factory rental/opponent generation
- Battle Factory selection and swap screen display
- Tents and Trainer Hill are unaffected

## Files changed

- `src/battle_tower.c` — Flip 2 high-tier checks to `FRONTIER_LVL_50`
- `src/battle_factory.c` — Flip 2 high-tier checks, replace level constant with `GetFrontierEnemyMonLevel()`
- `src/battle_factory_screen.c` — Replace inverted level branch with `GetFrontierEnemyMonLevel()`