### PR TITLE
Disable designated follower in Battle Pike (same as Pyramid)

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2,6 +2,7 @@
 #include "malloc.h"
 #include "battle_anim.h"
 #include "battle_pyramid.h"
+#include "battle_pike.h"
 #include "battle_script_commands.h"
 #include "berry.h"
 #include "debug.h"
@@ -2063,6 +2064,7 @@ struct Pokemon *GetDesignatedFollowerMon(void) {
         u8 df = gSaveBlock1Ptr->designatedFollower;
         if (df != 0 && df <= PARTY_SIZE
             && !InBattlePyramid()
+            && !InBattlePike()
             && GetMonData(&gPlayerParty[df - 1], MON_DATA_SPECIES) != SPECIES_NONE
             && GetMonData(&gPlayerParty[df - 1], MON_DATA_HP) > 0
             && !GetMonData(&gPlayerParty[df - 1], MON_DATA_IS_EGG))
@@ -2259,6 +2261,7 @@ static bool8 GetFollowerInfo(u16 *species, u8 *form, u8 *shiny)
         u8 df = gSaveBlock1Ptr->designatedFollower; // 0 = none, 1-6 = slot+1
         if (df != 0 && df <= PARTY_SIZE
             && !InBattlePyramid()
+            && !InBattlePike()
             && GetMonData(&gPlayerParty[df - 1], MON_DATA_SPECIES) != SPECIES_NONE
             && GetMonData(&gPlayerParty[df - 1], MON_DATA_HP) > 0
             && !GetMonData(&gPlayerParty[df - 1], MON_DATA_IS_EGG))


### PR DESCRIPTION
## Bug

The designated follower system was disabled for the Battle Pyramid but not the Battle Pike. In the Pike, the player's chosen follower Pokémon would display instead of falling back to the first live party mon. This could show the wrong Pokémon following the player when their party is reduced for the facility.

## Fix

Add `!InBattlePike()` check alongside the existing `!InBattlePyramid()` check in both `GetDesignatedFollowerMon()` and `GetFollowerInfo()`. When inside the Pike, the follower falls back to the first live mon in party — same behavior as the Pyramid. The designated follower restores automatically when the player exits.

## Files changed
- `src/event_object_movement.c` — Add `#include "battle_pike.h"` and `!InBattlePike()` guard in two locations