### PR TITLE
feat: allow Rare Candy to trigger evolution at level cap

### DIFF
--- a/include/strings.h
+++ b/include/strings.h
@@ -522,6 +522,7 @@ extern const u8 gText_12PoofForgotMove[];
 extern const u8 gText_StopLearningMove2[];
 extern const u8 gText_MoveNotLearned[];
 extern const u8 gText_PkmnElevatedToLvVar2[];
+extern const u8 gText_RareCandyUsedNoLevelUp[];
 extern const u8 gText_RemoveMailBeforeItem[];
 extern const u8 gText_PkmnHoldingItemCantHoldMail[];
 extern const u8 gText_MailTransferredFromMailbox[];

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -418,6 +418,7 @@ static void Task_HandleStopLearningMoveYesNoInput(u8);
 static void Task_TryLearningNextMoveAfterText(u8);
 static void BufferMonStatsToTaskData(struct Pokemon *, s16 *);
 static void UpdateMonDisplayInfoAfterRareCandy(u8, struct Pokemon *);
+static void Task_RareCandyEvoAtCap(u8);
 static void Task_DisplayLevelUpStatsPg1(u8);
 static void DisplayLevelUpStatsPg1(u8);
 static void Task_DisplayLevelUpStatsPg2(u8);
@@ -5383,6 +5384,26 @@ void ItemUseCB_RareCandy(u8 taskId, TaskFunc task)
     }
     else
     {
+        // At level cap — check if evolution is possible
+#ifdef POKEMON_EXPANSION
+        u16 targetSpecies = GetEvolutionTargetSpecies(mon, EVO_MODE_NORMAL, ITEM_NONE, NULL);
+#else
+        u16 targetSpecies = GetEvolutionTargetSpecies(mon, EVO_MODE_NORMAL, ITEM_NONE);
+#endif
+        if (targetSpecies != SPECIES_NONE)
+        {
+            // Evolution available at cap: consume candy, show message, then evolve
+            PlaySE(SE_SELECT);
+            gPartyMenuUseExitCallback = TRUE;
+            PlayFanfareByFanfareNum(FANFARE_LEVEL_UP);
+            RemoveBagItem(gSpecialVar_ItemId, 1);
+            GetMonNickname(mon, gStringVar1);
+            StringExpandPlaceholders(gStringVar4, gText_RareCandyUsedNoLevelUp);
+            DisplayPartyMenuMessage(gStringVar4, TRUE);
+            ScheduleBgCopyTilemapToVram(2);
+            gTasks[taskId].func = Task_RareCandyEvoAtCap;
+            return;
+        }
         cannotUseEffect = TRUE;
     }
     PlaySE(SE_SELECT);
@@ -5405,6 +5426,15 @@ void ItemUseCB_RareCandy(u8 taskId, TaskFunc task)
         DisplayPartyMenuMessage(gStringVar4, TRUE);
         ScheduleBgCopyTilemapToVram(2);
         gTasks[taskId].func = Task_DisplayLevelUpStatsPg1;
+    }
+}
+
+static void Task_RareCandyEvoAtCap(u8 taskId)
+{
+    if (WaitFanfare(FALSE) && IsPartyMenuTextPrinterActive() != TRUE && ((JOY_NEW(A_BUTTON)) || (JOY_NEW(B_BUTTON))))
+    {
+        PlaySE(SE_SELECT);
+        PartyMenuTryEvolution(taskId);
     }
 }
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -424,6 +424,7 @@ const u8 gText_PkmnRegainhedHealth[] = _("{STR_VAR_1} regained health.{PAUSE_UNT
 const u8 gText_PkmnBecameHealthy[] = _("{STR_VAR_1} became healthy.{PAUSE_UNTIL_PRESS}");
 const u8 gText_MovesPPIncreased[] = _("{STR_VAR_1}'s PP increased.{PAUSE_UNTIL_PRESS}");
 const u8 gText_PkmnElevatedToLvVar2[] = _("{STR_VAR_1} was elevated to\nLv. {STR_VAR_2}.");
+const u8 gText_RareCandyUsedNoLevelUp[] = _("Used Rare Candy on\n{STR_VAR_1}.");
 const u8 gText_PkmnBaseVar2StatIncreased[] = _("{STR_VAR_1}'s base {STR_VAR_2}\nstat was raised.{PAUSE_UNTIL_PRESS}");
 const u8 gText_PkmnFriendlyBaseVar2Fell[] = _("{STR_VAR_1} turned friendly.\nThe base {STR_VAR_2} fell!{PAUSE_UNTIL_PRESS}");
 const u8 gText_PkmnAdoresBaseVar2Fell[] = _("{STR_VAR_1} adores you!\nThe base {STR_VAR_2} fell!{PAUSE_UNTIL_PRESS}");


### PR DESCRIPTION
## Feature

Closes #74. When a Pokémon is at the level cap (or level 100), using a Rare Candy now checks for evolution eligibility. If the mon can evolve (via level, friendship, held item + time of day, known move, etc.), the candy is consumed and evolution is triggered without increasing the level.

This covers the case where a player has a Pokémon at cap that needs a "level up while holding X" or "level up with high friendship" evolution and has no other way to trigger it.

## Behavior

- **At cap, evolution available**: Candy consumed, displays "Used Rare Candy on [MON]", evolution scene plays. Level unchanged.
- **At cap, no evolution**: "Won't have any effect" — candy not consumed (same as before).
- **Below cap**: Normal behavior — level up, stat display, then evolution check.

## Examples

- Magneton holding Thunderstone at cap → uses Rare Candy → evolves to Magnezone
- Eevee with max friendship at cap → uses Rare Candy → evolves to Espeon/Umbreon (time-dependent)
- Pikachu at cap with no evolution path → "Won't have any effect"

## Files changed

- `src/party_menu.c` — Modified `ItemUseCB_RareCandy` to check evolution at cap; added `Task_RareCandyEvoAtCap`
- `src/strings.c` — Added `gText_RareCandyUsedNoLevelUp`
- `include/strings.h` — Added extern declaration