### PR TITLE
Fix night encounter table overshoot for maps without night table

### DIFF
--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -365,6 +365,8 @@ static u16 GetCurrentMapWildMonHeaderId(void)
         if (gWildMonHeaders[i].mapGroup == gSaveBlock1Ptr->location.mapGroup &&
             gWildMonHeaders[i].mapNum == gSaveBlock1Ptr->location.mapNum)
         {
+            u16 originalId = i;
+
             if (VarGet(VAR_ENCOUNTER_TABLE) >= 1 && VarGet(VAR_ENCOUNTER_TABLE) <= 4)
                 i += (VarGet(VAR_ENCOUNTER_TABLE) - 1);
             if (gSaveBlock1Ptr->location.mapGroup == MAP_GROUP(ALTERING_CAVE) &&
@@ -375,6 +377,15 @@ static u16 GetCurrentMapWildMonHeaderId(void)
                     alteringCaveId = 0;
 
                 i += alteringCaveId;
+            }
+
+            // Prevent night table overshoot: if the offset landed on a different
+            // map's header, fall back to modern day (originalId + 1).
+            if (VarGet(VAR_ENCOUNTER_TABLE) == 3
+                && (gWildMonHeaders[i].mapGroup != gWildMonHeaders[originalId].mapGroup
+                    || gWildMonHeaders[i].mapNum != gWildMonHeaders[originalId].mapNum))
+            {
+                i = originalId + 1;
             }
 
             return i;


### PR DESCRIPTION
## Bug

When `VAR_ENCOUNTER_TABLE` is 3 (night mode), `GetCurrentMapWildMonHeaderId` adds 2 to the header index. For maps that only have 2 encounter headers (vanilla + modern day, no night table), this overshoots into the next map's encounter data in `gWildMonHeaders`. Players encounter wrong Pokémon from a completely different map.

Affects 95 maps (all caves/dungeons and water routes without dedicated night tables) when playing at night with modern encounters enabled.

## Fix

After applying the table offset, verify the resulting header still belongs to the same map. If it doesn't (overshoot), fall back to modern day table (index + 1).

Based on fix by @deepCeadeus ([[89b39fb]

## Files changed
- `src/wild_encounter.c` — Added bounds check in `GetCurrentMapWildMonHeaderId`