### PR TITLE
Fix 2x battle speed breaking palette fades (e.g. Hyper Beam)

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2135,7 +2135,8 @@ void BattleMainCB2(void)
 
     if (gSaveBlock2Ptr->optionsBattleSpeed
         && !(gBattleTypeFlags & BATTLE_TYPE_LINK)
-        && !gBattleCaptureSuccessActive)
+        && !gBattleCaptureSuccessActive
+        && !gPaletteFade.active)
     {
         bool8 ballActive = FALSE;
         u8 i;


### PR DESCRIPTION
## Bug

With the 2x battle speed option enabled, Hyper Beam (and other moves using screen fades) darkens the background but never restores it. The battle continues with a permanently black background.

## Cause

The 2x speed works by running sprite callbacks, `AnimateSprites()`, and `RunTasks()` twice per frame. However, `UpdatePaletteFade()` only runs once per frame. This desync causes the animation system to advance past the palette fade — the unfade sprite gets created and immediately checks `!gPaletteFade.active`, which may resolve before the palette system processes the fade, destroying the sprite before the unfade ever executes.

## Fix

Add `!gPaletteFade.active` as a condition for the double-tick block. When a palette fade is in progress, the battle runs at normal speed until the fade completes. This ensures the palette system stays in sync with the animation system. The 2x speedup resumes immediately after.

## Affected moves
- Hyper Beam
- Solar Beam
- Any move animation using `gSimplePaletteBlendSpriteTemplate` for screen darkening/brightening
