### PR TITLE
Fix summary screen animation hang when pressing A without Pokédex

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -1965,10 +1965,18 @@ static void Task_HandleInput(u8 taskId)
             {
                 if (sMonSummaryScreen->currPageIndex == PSS_PAGE_INFO)
                 {
-                    StopPokemonAnimations();
-                    PlaySE(SE_SELECT);
-                    // Open the Pokedex entry for this species
-                    CB2_ShowPokedexEntryFromSummary();
+                    if (!sMonSummaryScreen->summary.isEgg && FlagGet(FLAG_SYS_POKEDEX_GET) == TRUE)
+                    {
+                        StopPokemonAnimations();
+                        PlaySE(SE_SELECT);
+                        CB2_ShowPokedexEntryFromSummary();
+                    }
+                    else
+                    {
+                        StopPokemonAnimations();
+                        PlaySE(SE_SELECT);
+                        BeginCloseSummaryScreen(taskId);
+                    }
                 }
                 else // Contest or Battle Moves
                 {


### PR DESCRIPTION
## Bug

Before receiving the Pokédex from Prof. Birch, pressing A on the summary INFO page freezes sprite animations. The prompt correctly shows "[A] Cancel" but pressing it calls `StopPokemonAnimations()` unconditionally, then attempts to open the dex which silently fails due to the missing flag. Animations stay frozen for the rest of the summary session.

## Fix

Check `FLAG_SYS_POKEDEX_GET` before acting on the A press:
- **With Pokédex**: Opens dex entry (existing behavior)
- **Without Pokédex**: Closes the summary screen (matches "Cancel" label)

## Note

The separate "green square" issue when opening the Pokédex from summary is unrelated — that requires the flag to be set and is likely a sprite/tile cleanup problem in the summary→pokedex transition.

Fixes #167 core problem