### PR TITLE
Fix tilemap artifacts when opening Pokédex from summary screen

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -1898,6 +1898,16 @@ static void Task_OpenPokedexFromSummary(u8 taskId)
         FreeSummaryScreen();
         DestroyTask(taskId);
         
+        // Clear all BG tilemaps to prevent leftover tiles bleeding into the Pokédex screen
+        FillBgTilemapBufferRect_Palette0(0, 0, 0, 0, 32, 32);
+        FillBgTilemapBufferRect_Palette0(1, 0, 0, 0, 32, 32);
+        FillBgTilemapBufferRect_Palette0(2, 0, 0, 0, 32, 32);
+        FillBgTilemapBufferRect_Palette0(3, 0, 0, 0, 32, 32);
+        CopyBgTilemapBufferToVram(0);
+        CopyBgTilemapBufferToVram(1);
+        CopyBgTilemapBufferToVram(2);
+        CopyBgTilemapBufferToVram(3);
+
         // Open the Pokédex info screen for this specific Pokémon
         OpenPokedexInfoScreen(species, CB2_ReturnToSummaryFromPokedex);
     }


### PR DESCRIPTION
Clear all BG tilemaps after summary cleanup and before opening the Pokédex info screen. Leftover tiles from summary windows (text labels, button prompts, etc.) could bleed through on BG regions the Pokédex doesn't explicitly overwrite. The clear runs while the screen is fully faded to black, so it's invisible to the player.
