### PR TITLE
Fix static randomizer not applying to event mon encounters (legendaries)

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5748,6 +5748,10 @@ void CreateEnemyEventMon(void)
     s32 level = gSpecialVar_0x8005;
     s32 itemId = gSpecialVar_0x8006;
 
+    //tx_randomizer_and_challenges
+    if (gSaveBlock1Ptr->tx_Random_Static)
+        species = GetSpeciesRandomSeeded(species, TX_RANDOM_T_STATIC, 0);
+
     ZeroEnemyPartyMons();
     CreateEventMon(&gEnemyParty[0], species, level, USE_RANDOM_IVS, FALSE, 0, OT_ID_PLAYER_ID, 0);
     if (itemId)


### PR DESCRIPTION
CreateEnemyEventMon (used by seteventmon for legendaries like Rayquaza, Kyogre, Groudon, Jirachi, etc.) was missing the tx_Random_Static check. Only CreateScriptedWildMon (setwildbattle) applied the randomizer. Now both paths respect the Static Pokémon randomizer setting.

addresses issue: https://www.pokecommunity.com/threads/pok%C3%A9mon-modern-emerald-3-5-open-source-double-speed-battles-following-pok%C3%A9mon-better-battle-frontier-and-more.494005/post-10999982