### PR TITLE
Fix Challenge Viewer freeze when accessed from PC menu

### DIFF
--- a/data/scripts/pc.inc
+++ b/data/scripts/pc.inc
@@ -37,8 +37,8 @@ EventScript_AccessPC_AfterLeague::
 
 EventScript_ChallengeViewer::
 	playse SE_PC_LOGIN
-	callnative Task_ChallengeViewer
-	delay 30
+	special Special_OpenChallengeViewer
+	waitstate
 	goto EventScript_PCMainMenu
 	end
 

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -570,4 +570,5 @@ gSpecials::
 	def_special SwitchMonAbility
 	def_special DoSlidingPuzzle
     def_special NameRival
+    def_special Special_OpenChallengeViewer
 

--- a/src/tx_rac_viewer.c
+++ b/src/tx_rac_viewer.c
@@ -1172,6 +1172,13 @@ static void Viewer_RedrawList(void)
 
 // ---- Entry point from field ----------------------------------------------------
 
+// Called as a special (no taskId) — mirrors the PlayerPC pattern with waitstate.
+void Special_OpenChallengeViewer(void)
+{
+    gMain.savedCallback = CB2_ReturnToFieldContinueScript;
+    SetMainCallback2(CB2_InitChallengeViewer);
+}
+
 void Task_ChallengeViewer(u8 taskId)
 {
     gMain.savedCallback = CB2_ReturnToFieldContinueScript; // return to continue script, prevents player moving


### PR DESCRIPTION
Fixes #171 - this one was a doozy lol.

## Bug

Opening the Challenge Viewer from the PC (PC → Challenges) causes the game to freeze on the Release 3.5 build. Music continues playing but the screen is stuck and no input is accepted.

## Root Cause

The script `EventScript_ChallengeViewer` used `callnative Task_ChallengeViewer` followed by `delay 30` + `goto EventScript_PCMainMenu`. This had two critical problems:

**1. Wrong calling convention.** `callnative` calls the function with no arguments, but `Task_ChallengeViewer` expects a `u8 taskId` parameter. The `taskId` received garbage from whatever happened to be in r0. The `DestroyTask(taskId)` call at the end destroyed a random unrelated task.

**2. Script ran concurrently with viewer init.** `callnative` does not suspend the script context — it returns immediately and the script keeps executing. After 30 frames, `goto EventScript_PCMainMenu` ran while `CB2_InitChallengeViewer` was still in the middle of its init sequence. The PC menu restart called `SetMainCallback2` with a different callback, resetting `gMain.state = 0` and restarting the viewer init loop — resulting in the visible freeze.

**Debugger analysis confirmed:** `gMain.callback2 = CB2_InitChallengeViewer`, `gMain.state` oscillating at 1, `gPaletteFade.active = FALSE` (fade completed), but no Viewer task existed in `gTasks`. The script had already torn down the environment before the viewer could complete.

## Why It Appeared Fixed on Newer Builds

The subsequent commits (`f6a0889a9` — battle speed palette fix, and others) changed code size in `battle_main.c` and `pokemon_summary_screen.c`, which shifted ROM layout and IWRAM placement. This altered the timing of the concurrent script/viewer execution just enough to avoid the freeze in some cases — but the underlying bug remained and would resurface with any future code size changes.

## Fix

Added `Special_OpenChallengeViewer()` — a proper no-argument special function that sets the saved callback and main callback without the bogus `DestroyTask`. Added it to `specials.inc`. Changed the script to:

```
special Special_OpenChallengeViewer
waitstate
goto EventScript_PCMainMenu
```

This mirrors the exact pattern used by `PlayerPC` and every other full-screen menu in the codebase. `waitstate` suspends the script until the viewer calls `SetMainCallback2(gMain.savedCallback)` on exit, which triggers `CB2_ReturnToFieldContinueScript` to properly resume the script context.

## Why This Won't Recur

The `special` + `waitstate` pattern is a fundamental GBA scripting contract — the script is fully suspended while the menu is active, with no concurrent execution. Changes to ROM layout, code size, or timing have no effect on this pattern. The only way it could break is if `CB2_ReturnToFieldContinueScript` is not called on exit, which the viewer already handles correctly.

## Files Changed
- `src/tx_rac_viewer.c` — Added `Special_OpenChallengeViewer()` alongside the existing `Task_ChallengeViewer`
- `data/specials.inc` — Registered `Special_OpenChallengeViewer`
- `data/scripts/pc.inc` — Changed `callnative` + `delay 30` to `special` + `waitstate`