### PR TITLE
Fix stale tile artifacts in Pokédex info screen from summary path

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -3931,6 +3931,21 @@ static void Task_LoadInfoScreen(u8 taskId)
         CopyWindowToVram(WIN_INFO, COPYWIN_FULL);
         CopyBgTilemapBufferToVram(1);
         CopyBgTilemapBufferToVram(2);
+        // Reload BG3 tilemap to fix corruption between init cases.
+        {
+            extern const u32 gPokedexPlusHGSS_ScreenInfo_Tilemap[];
+            LZ77UnCompWram(gPokedexPlusHGSS_ScreenInfo_Tilemap, GetBgTilemapBuffer(3));
+        }
+        if (GetShinySeenFlag(sPokedexListItem->dexNum))
+        {
+            u16 *buf = (u16 *)GetBgTilemapBuffer(3);
+            buf[9 * 32 + 14] = 208; buf[9 * 32 + 15] = 209;
+            buf[9 * 32 + 16] = 210; buf[9 * 32 + 17] = 211;
+            buf[10 * 32 + 14] = 212; buf[10 * 32 + 15] = 213;
+            buf[10 * 32 + 16] = 214; buf[10 * 32 + 17] = 215;
+            buf[11 * 32 + 14] = 216; buf[11 * 32 + 15] = 217;
+            buf[11 * 32 + 16] = 218; buf[11 * 32 + 17] = 219;
+        }
         CopyBgTilemapBufferToVram(3);
         gMain.state++;
         break;
@@ -4038,6 +4053,12 @@ static void FreeInfoScreenWindowAndBgBuffers(void)
 
 static void Task_HandleInfoScreenInput(u8 taskId)
 {
+    // Fix BG3 tilemap entries corrupted by stale DMA writes each VBlank.
+    // Write directly to VRAM since the RAM buffer gets re-corrupted every frame.
+    // mapBaseIndex 15 for BG3 on the info screen.
+    *(vu16 *)(BG_SCREEN_ADDR(15) + 553 * 2) = 65;   // row 17 col 9: background fill
+    *(vu16 *)(BG_SCREEN_ADDR(15) + 628 * 2) = 111;  // row 19 col 20: border
+
     if (gTasks[taskId].tScrolling)
     {
         // Scroll up/down


### PR DESCRIPTION
fixes #172 - albeit somewhat a bandaid but a working one.  i cannot for the life of me find the source of the BG3 map corruption.

## Bug

When opening the Pokédex from PC → Summary (skipping the main dex list screen), stale tile artifacts appear:
1. A corrupt tile in the description text area (row 17, col 9 → tile 256)
2. A corrupt tile at the border (row 19, col 20 → tile 0/1) after using the shiny toggle

Only reproducible after opening the normal Pokédex outdoors first, then entering a Pokémon Center and using the PC → Summary → Pokédex path.

## Root Cause

The "from summary" path (`OpenPokedexInfoScreen`) jumps directly to the info screen, skipping the normal dex list screen (`LoadPokedexListPage`). The BG3 tilemap RAM buffer gets corrupted between init cases by stale DMA requests from the previous screen (PC/summary) that fire during VBlank via `ProcessDma3Requests`. These overwrite specific entries in the buffer after `CopyToBgTilemapBuffer` correctly loads the tilemap.

**Debugger-confirmed findings:**
- Entry 553 (row 17, col 9) changes from `0x0041` (correct) to `0x0100` (tile 256) between cases 2 and 3 of `Task_LoadInfoScreen`
- Entry 628 (row 19, col 20) gets corrupted to tile 0 or 1 after shiny toggle
- The corruption occurs during VBlank between task cases — not caused by any specific function call
- `ResetTasks()`, `ClearDma3Requests()`, and disabling VBlank callbacks all failed to prevent it
- Any code modifications to `PrintShinyToggleLabel` (even trivial buffer writes) trigger a latent toggle freeze after 2 uses due to code alignment sensitivity

## Fix

Two-part approach:

**1. Case 4 tilemap reload (one-time, during init):**
Reload the full BG3 tilemap from the LZ77 asset right before the final VRAM copy in case 4 of `Task_LoadInfoScreen`. This runs on the same frame as the copy — no VBlank can corrupt it in between.

**2. Per-frame VRAM correction (continuous, during input handling):**
Write the correct tile values directly to VRAM at the two known corrupt positions every frame in `Task_HandleInfoScreenInput`. This uses direct VRAM writes (`*(vu16 *)(BG_SCREEN_ADDR(15) + entry * 2) = tile`) rather than buffer writes, ensuring the correction persists regardless of buffer state.

This approach:
- Does NOT modify `PrintShinyToggleLabel` (avoids the latent toggle freeze)
- Uses `BG_SCREEN_ADDR(15)` for maintainability (derived from mapBaseIndex)
- Costs only 2 halfword VRAM writes per frame (~2 CPU cycles)
- Shiny toggle works unlimited times without artifacts

## If future junk tiles appear

The same pattern can be applied: identify the corrupt tile's entry index in the BG3 tilemap (using mGBA Map Viewer → click tile → note Map Addr, subtract `BG_SCREEN_ADDR(15)`, divide by 2), look up the correct tile from the asset, and add another `*(vu16 *)(BG_SCREEN_ADDR(15) + INDEX * 2) = CORRECT_TILE;` line in `Task_HandleInfoScreenInput`.

## Files changed
- `src/pokedex_plus_hgss.c` — Added tilemap reload in `Task_LoadInfoScreen` case 4; added per-frame VRAM correction in `Task_HandleInfoScreenInput`