### PR TITLE
Skip AREA and SIZE screens in Pokédex when opened from battle summary

### DIFF
--- a/src/pokedex_plus_hgss.c
+++ b/src/pokedex_plus_hgss.c
@@ -4106,12 +4106,25 @@ static void Task_HandleInfoScreenInput(u8 taskId)
 
     if ((JOY_NEW(DPAD_RIGHT) || (JOY_NEW(R_BUTTON) && gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_LR)))
     {
-        sPokedexView->selectedScreen = AREA_SCREEN;
-        StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
-        BeginNormalPaletteFade(0xFFFFFFEB, 0, 0, 0x10, RGB_BLACK);
-        sPokedexView->screenSwitchState = 1;
-        gTasks[taskId].func = Task_SwitchScreensFromInfoScreen;
-        PlaySE(SE_PIN);
+        if (gMain.inBattle)
+        {
+            // Skip AREA screen in battle (tiles are garbled from battle VRAM state)
+            sPokedexView->selectedScreen = STATS_SCREEN;
+            StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
+            BeginNormalPaletteFade(0xFFFFFFEB, 0, 0, 0x10, RGB_BLACK);
+            sPokedexView->screenSwitchState = 4;
+            gTasks[taskId].func = Task_SwitchScreensFromInfoScreen;
+            PlaySE(SE_PIN);
+        }
+        else
+        {
+            sPokedexView->selectedScreen = AREA_SCREEN;
+            StopMonSpriteAnimation(gTasks[taskId].tMonSpriteId);
+            BeginNormalPaletteFade(0xFFFFFFEB, 0, 0, 0x10, RGB_BLACK);
+            sPokedexView->screenSwitchState = 1;
+            gTasks[taskId].func = Task_SwitchScreensFromInfoScreen;
+            PlaySE(SE_PIN);
+        }
     }
 
 }
@@ -4133,6 +4146,9 @@ static void Task_SwitchScreensFromInfoScreen(u8 taskId)
             break;
         case 3:
             gTasks[taskId].func = Task_LoadSizeScreen;
+            break;
+        case 4:
+            gTasks[taskId].func = Task_LoadStatsScreen;
             break;
         }
     }
@@ -6606,7 +6622,10 @@ static void Task_SwitchScreensFromStatsScreen(u8 taskId)
         case 1:
             FreeAllWindowBuffers();
             InitWindows(sInfoScreen_WindowTemplates);
-            gTasks[taskId].func = Task_LoadAreaScreen;
+            if (gMain.inBattle)
+                gTasks[taskId].func = Task_LoadInfoScreen;
+            else
+                gTasks[taskId].func = Task_LoadAreaScreen;
             break;
         case 2:
             gTasks[taskId].func = Task_LoadCryScreen;
@@ -7943,7 +7962,7 @@ static void Task_HandleCryScreenInput(u8 taskId)
         if (JOY_NEW(DPAD_RIGHT)
          || (JOY_NEW(R_BUTTON) && gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_LR))
         {
-            if (!sPokedexListItem->owned)
+            if (!sPokedexListItem->owned || gMain.inBattle)
             {
                 PlaySE(SE_FAILURE);
             }


### PR DESCRIPTION
Resolves #179 


## Bug

Opening the Pokédex from the battle summary and navigating to the AREA or SIZE screens shows completely garbled tiles — the region map is unreadable and the SIZE screen is missing the Pokémon sprite.

## Cause

The battle uses VRAM extensively (battle sprites, animated BGs, palette effects). When the Pokédex opens from battle summary, the AREA and SIZE screens' tile/tilemap loading fails to properly initialize over the battle's VRAM state. The INFO, STATS, EVO, and CRY screens initialize correctly because they use different BG configurations that happen to work.

## Why not fix AREA and SIZE directly?

The AREA screen uses its own region map tileset with a complex multi-step init (`pokedex_area_region_map.c`). The SIZE screen has a trainer silhouette sprite system. Both rely on specific VRAM/charbase states that conflict with residual battle data. Debugging the INFO screen's single-tile corruption alone took extensive investigation and revealed the underlying DMA/VBlank write issue is extremely difficult to trace. Attempting the same for two additional screens with completely different BG configurations would carry high risk of introducing regressions — for screens that provide no actionable information during battle.

## Fix

Disable navigation to AREA and SIZE when the Pokédex is opened during battle (`gMain.inBattle`):

- **INFO → right**: Skips AREA, goes directly to STATS
- **STATS → left**: Skips AREA, goes directly to INFO
- **CRY → right**: Blocks with `SE_FAILURE` sound (can't reach SIZE)

This matches the existing pattern for unowned Pokémon, where inaccessible tabs play `SE_FAILURE` and navigation skips them. INFO, STATS, EVO, and CRY remain fully functional during battle.

## Files changed
- `src/pokedex_plus_hgss.c` — Added `gMain.inBattle` checks in `Task_HandleInfoScreenInput`, `Task_SwitchScreensFromInfoScreen`, `Task_SwitchScreensFromStatsScreen`, and the CRY screen input handler