### PR TITLE
Fix hold item bonus not applying correctly with phys/special split

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6433,8 +6433,10 @@ s32 CalculateBaseDamage(struct BattlePokemon *attacker, struct BattlePokemon *de
             if (attackerHoldEffect == sHoldEffectToType[i][0]
                 && type == sHoldEffectToType[i][1])
             {
-                attack = (attack * (attackerHoldEffectParam + 100)) / 100;
-                spAttack = (spAttack * (attackerHoldEffectParam + 100)) / 100;
+                if (IS_MOVE_SPECIAL(gCurrentMove))
+                    spAttack = (spAttack * (attackerHoldEffectParam + 100)) / 100;
+                else
+                    attack = (attack * (attackerHoldEffectParam + 100)) / 100;
                 break;
             }
     }


### PR DESCRIPTION
When optionStyle == 0 (modern phys/special split), hold items like Charcoal were boosting both attack AND spAttack unconditionally. Now correctly uses IS_MOVE_SPECIAL(gCurrentMove) to only boost the relevant stat based on the move's category.

Ref: resetes12/pokeemerald#181 per https://github.com/deepCeadeus

