### PR TITLE
Fix Safari Zone freeze when quick-running after a double battle

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -4276,7 +4276,6 @@ static void BattleIntroSafariQuickRun(void)
             if ((JOY_HELD(R_BUTTON)) && (JOY_HELD(L_BUTTON)))
             {
                 PlaySE(SE_FLEE);
-                gBattlerAttacker = gBattlerByTurnOrder[gCurrentTurnActionNumber];
                 gBattleOutcome = B_OUTCOME_RAN;
                 gBattleMainFunc = HandleEndTurn_RanFromBattle;
                 return;
@@ -4300,7 +4299,6 @@ static void BattleIntroSafariQuickRun(void)
 
                 sSafariRunHoldCounter = 0;
                 PlaySE(SE_FLEE);
-                gBattlerAttacker = gBattlerByTurnOrder[gCurrentTurnActionNumber];
                 gBattleOutcome = B_OUTCOME_RAN;
                 gBattleMainFunc = HandleEndTurn_RanFromBattle;
                 return;


### PR DESCRIPTION
gBattlerByTurnOrder[gCurrentTurnActionNumber] is uninitialized during the battle intro phase. Accessing it after a double battle can read stale/garbage data and freeze the game. The assignment to gBattlerAttacker is unnecessary for Safari Zone escape since the outcome is always B_OUTCOME_RAN regardless of attacker.

Ref: resetes12/pokeemerald#181 per https://github.com/deepCeadeus