### PR TITLE
Fix secret base battle not restoring party stats after level cap

### DIFF
--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -2160,6 +2160,12 @@ static void HandleSpecialTrainerBattleEnd(void)
             u16 itemBefore = GetMonData(&gSaveBlock1Ptr->playerParty[i], MON_DATA_HELD_ITEM);
             SetMonData(&gPlayerParty[i], MON_DATA_HELD_ITEM, &itemBefore);
         }
+        if (FlagGet(FLAG_LIMIT_TO_50))
+        {
+            FlagClear(FLAG_LIMIT_TO_50);
+            for (i = 0; i < PARTY_SIZE; i++)
+                CalculateMonStats(&gPlayerParty[i]);
+        }
         break;
     case SPECIAL_BATTLE_EREADER:
         CopyEReaderTrainerFarewellMessage();


### PR DESCRIPTION
After a secret base battle, FLAG_LIMIT_TO_50 was never cleared and CalculateMonStats was not called. This left the party with capped stats post-battle. Now properly clears the flag and recalculates stats, matching the pattern used by other special battle types.

Ref: resetes12/pokeemerald#181 per https://github.com/deepCeadeus
