### PR TITLE
Fix move type display not reflecting ability type changes

### DIFF
--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -7,6 +7,7 @@
 #include "battle_dome.h"
 #include "battle_interface.h"
 #include "battle_message.h"
+#include "battle_script_commands.h"
 #include "battle_setup.h"
 #include "battle_tv.h"
 #include "bg.h"
@@ -1837,7 +1838,7 @@ u8 TypeEffectiveness(u8 targetId)
 
 bool8 IsMoveSTAB(u16 move, u8 battlerId)
 {
-	u8 moveType = gBattleMoves[move].type;
+	u8 moveType = DisplayMoveTypeChange(move);
 
     if (IS_MOVE_STATUS(move))
         return FALSE;
@@ -1901,7 +1902,7 @@ static void MoveSelectionDisplayMoveTypeDoubles(u8 targetId)
     u16 move = moveInfo->moves[gMoveSelectionCursor[gActiveBattler]];
 
     moveCategory = gBattleMoves[move].category;
-    type = gBattleMoves[move].type;
+    type = DisplayMoveTypeChange(move);
 
     if (move == MOVE_HIDDEN_POWER)
     {
@@ -1951,7 +1952,7 @@ static void MoveSelectionDisplayMoveType(void) //Made this display a Move Type I
     u16 move = moveInfo->moves[gMoveSelectionCursor[gActiveBattler]];
 
     moveCategory = gBattleMoves[move].category;
-    type = gBattleMoves[move].type;
+    type = DisplayMoveTypeChange(move);
 
     if (move == MOVE_HIDDEN_POWER)
     {


### PR DESCRIPTION
Pixilate and Forecast change Normal moves to other types during battle, but the move selection UI still displayed the base Normal type. Now calls DisplayMoveTypeChange() to show the actual type after ability modification. Also fixes the STAB indicator for ability-changed moves (e.g. Sylveon's Normal moves now correctly show STAB since they become Fairy via Pixilate).

Ref: resetes12/pokeemerald#181 per https://github.com/deepCeadeus

