### PR TITLE
Move shiny scan from every-load to one-time migration

### DIFF
--- a/src/load_save.c
+++ b/src/load_save.c
@@ -233,7 +233,6 @@ void CopyPartyAndObjectsFromSave(void)
     PrintTXSaveData(); //tx_randomizer_and_challenges
     LoadPlayerParty();
     LoadObjectEvents();
-    ScanOwnedMonsForShinies(); // Retroactively set shiny flags for existing party/PC mons
 }
 
 void LoadPlayerBag(void)

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -1164,6 +1164,9 @@ static void Task_VersionUpdater_WaitComplete(u8 taskId)
 
 static void Task_VersionUpdater_Finish(u8 taskId)
 {
+    // Retroactively set shiny-seen flags for any shinies already in party/PC/daycare
+    ScanOwnedMonsForShinies();
+
     StampCurrentSaveVersion();
     // Clear the full BG0 tilemap so main menu draws on a clean slate
     FillBgTilemapBufferRect_Palette0(0, 0, 0, 0, 30, 20);


### PR DESCRIPTION
ScanOwnedMonsForShinies() iterated through all party, PC boxes, and daycare mons on every save load to retroactively set shiny-seen flags. This was only needed for saves that predate the shiny-seen system.

Moved the scan to Task_VersionUpdater_Finish so it runs once during save migration. Going forward, individual SetShinySeenFlag calls in encounter/catch/hatch/evolution code handle new shinies as they occur.

This is a cleaner approach, since before we didn't have a "migration" system to lean on when old/no versions were detected, so I just ran it everytime.