### PR TITLE
Fix shadow disappearing near reflective water

### DIFF
--- a/src/field_effect_helpers.c
+++ b/src/field_effect_helpers.c
@@ -404,7 +404,6 @@ void UpdateShadowFieldEffect(struct Sprite *sprite)
         sprite->invisible = linkedSprite->invisible;
         if (!objectEvent->active
          || objectEvent->noShadow
-         || objectEvent->hasReflection
          || objectEvent->inHotSprings
          || objectEvent->inSandPile
          || gWeatherPtr->noShadows


### PR DESCRIPTION
PR #147 added 'objectEvent->hasReflection' to the shadow kill conditions in UpdateShadowFieldEffect. This caused shadows to disappear for any object standing on grass adjacent to reflective water (since hasReflection is set when a nearby tile is reflective).

The other checks already added in PR #147 (MetatileBehavior_IsBridgeOverWater, MetatileBehavior_IsReflective, PLAYER_AVATAR_FLAG_SURFING) correctly handle the intended cases (no shadow while surfing or on bridges) without the overly broad hasReflection flag.

Fixes #146 