### PR TITLE
clarification for agbcc installation in the Linux install steps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -415,7 +415,7 @@ If this works, then proceed to [Installation](#installation). Otherwise, ask for
     git clone https://github.com/pret/agbcc
     cd agbcc
     ./build.sh
-    ./install.sh ../pokeemerald
+    ./install.sh ../
     ```
 
 - **Otherwise**, if agbcc has been built before (e.g. if the git clone above fails), but was **last built on a different terminal** than the one currently used (only relevant to Windows, e.g. switching from msys2 to WSL1), then run the following commands to build and install it into pokeemerald:


### PR DESCRIPTION
In the linux install steps, the install scripts require a landing folder. The documentation states that we should already be in the pokeemerald folder. Therefor ../pokeemerald doesn't exists, it should be ../../pokeemerald or rather simply ../ as to not imply that we already know the folder name, which was up to the user to decide.